### PR TITLE
Layer 1: core primitives

### DIFF
--- a/crates/fitsio-pure/src/block.rs
+++ b/crates/fitsio-pure/src/block.rs
@@ -1,0 +1,346 @@
+/// FITS block size in bytes (each logical record is one block).
+pub const BLOCK_SIZE: usize = 2880;
+
+/// FITS card (keyword record) size in bytes.
+pub const CARD_SIZE: usize = 80;
+
+/// Number of cards that fit in a single block.
+pub const CARDS_PER_BLOCK: usize = BLOCK_SIZE / CARD_SIZE;
+
+/// Padding byte used for header blocks (ASCII space).
+pub const HEADER_PAD_BYTE: u8 = 0x20;
+
+/// Padding byte used for data blocks (zero).
+pub const DATA_PAD_BYTE: u8 = 0x00;
+
+/// Returns the number of FITS blocks required to hold `num_bytes` bytes.
+///
+/// A FITS file is organized in units of 2880 bytes. This computes the ceiling
+/// division: 0 bytes requires 0 blocks, 1 byte requires 1 block, 2880 bytes
+/// requires 1 block, 2881 bytes requires 2 blocks, etc.
+pub const fn blocks_needed(num_bytes: usize) -> usize {
+    if num_bytes == 0 {
+        return 0;
+    }
+    num_bytes.div_ceil(BLOCK_SIZE)
+}
+
+/// Returns the total byte length (in whole blocks) required to hold `num_bytes`.
+///
+/// This is simply `blocks_needed(num_bytes) * BLOCK_SIZE`.
+pub const fn padded_byte_len(num_bytes: usize) -> usize {
+    blocks_needed(num_bytes) * BLOCK_SIZE
+}
+
+/// Copies `src` into the beginning of `dest` and fills the remaining bytes of
+/// `dest` with `pad_byte`.
+///
+/// `dest` must be at least as large as `src`. This is a general-purpose helper
+/// used by the header and data padding routines.
+///
+/// # Panics
+///
+/// Panics if `dest.len() < src.len()`.
+fn copy_and_pad(dest: &mut [u8], src: &[u8], pad_byte: u8) {
+    let len = src.len();
+    dest[..len].copy_from_slice(src);
+    let remaining = &mut dest[len..];
+    let mut i = 0;
+    while i < remaining.len() {
+        remaining[i] = pad_byte;
+        i += 1;
+    }
+}
+
+/// Writes `src` into `dest`, padding any trailing bytes in the final block with
+/// ASCII spaces (0x20) as required for FITS header blocks.
+///
+/// `dest` must have length equal to `padded_byte_len(src.len())`.
+///
+/// # Panics
+///
+/// Panics if `dest` is not the correct padded length.
+pub fn pad_header_blocks(dest: &mut [u8], src: &[u8]) {
+    assert_eq!(
+        dest.len(),
+        padded_byte_len(src.len()),
+        "dest length must equal the padded block length of src"
+    );
+    copy_and_pad(dest, src, HEADER_PAD_BYTE);
+}
+
+/// Writes `src` into `dest`, padding any trailing bytes in the final block with
+/// zero bytes (0x00) as required for FITS data blocks.
+///
+/// `dest` must have length equal to `padded_byte_len(src.len())`.
+///
+/// # Panics
+///
+/// Panics if `dest` is not the correct padded length.
+pub fn pad_data_blocks(dest: &mut [u8], src: &[u8]) {
+    assert_eq!(
+        dest.len(),
+        padded_byte_len(src.len()),
+        "dest length must equal the padded block length of src"
+    );
+    copy_and_pad(dest, src, DATA_PAD_BYTE);
+}
+
+/// Reads exactly one 2880-byte block from `src` starting at the given block
+/// index and copies it into `dest`.
+///
+/// # Panics
+///
+/// Panics if `dest.len() != BLOCK_SIZE` or if `src` does not contain enough
+/// bytes for the requested block.
+pub fn read_block(dest: &mut [u8; BLOCK_SIZE], src: &[u8], block_index: usize) {
+    let start = block_index * BLOCK_SIZE;
+    let end = start + BLOCK_SIZE;
+    assert!(
+        src.len() >= end,
+        "src does not contain block {}",
+        block_index
+    );
+    dest.copy_from_slice(&src[start..end]);
+}
+
+/// Writes exactly one 2880-byte block from `block` into `dest` at the given
+/// block index.
+///
+/// # Panics
+///
+/// Panics if `dest` does not have enough room to hold the block at the
+/// requested index.
+pub fn write_block(dest: &mut [u8], block: &[u8; BLOCK_SIZE], block_index: usize) {
+    let start = block_index * BLOCK_SIZE;
+    let end = start + BLOCK_SIZE;
+    assert!(
+        dest.len() >= end,
+        "dest does not have room for block {}",
+        block_index
+    );
+    dest[start..end].copy_from_slice(block);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- blocks_needed ----
+
+    #[test]
+    fn blocks_needed_zero() {
+        assert_eq!(blocks_needed(0), 0);
+    }
+
+    #[test]
+    fn blocks_needed_one_byte() {
+        assert_eq!(blocks_needed(1), 1);
+    }
+
+    #[test]
+    fn blocks_needed_exactly_one_block() {
+        assert_eq!(blocks_needed(BLOCK_SIZE), 1);
+    }
+
+    #[test]
+    fn blocks_needed_one_over() {
+        assert_eq!(blocks_needed(BLOCK_SIZE + 1), 2);
+    }
+
+    #[test]
+    fn blocks_needed_exactly_two_blocks() {
+        assert_eq!(blocks_needed(2 * BLOCK_SIZE), 2);
+    }
+
+    #[test]
+    fn blocks_needed_partial() {
+        assert_eq!(blocks_needed(100), 1);
+        assert_eq!(blocks_needed(2879), 1);
+        assert_eq!(blocks_needed(2881), 2);
+        assert_eq!(blocks_needed(5760), 2);
+        assert_eq!(blocks_needed(5761), 3);
+    }
+
+    // ---- padded_byte_len ----
+
+    #[test]
+    fn padded_byte_len_zero() {
+        assert_eq!(padded_byte_len(0), 0);
+    }
+
+    #[test]
+    fn padded_byte_len_aligned() {
+        assert_eq!(padded_byte_len(BLOCK_SIZE), BLOCK_SIZE);
+        assert_eq!(padded_byte_len(2 * BLOCK_SIZE), 2 * BLOCK_SIZE);
+    }
+
+    #[test]
+    fn padded_byte_len_unaligned() {
+        assert_eq!(padded_byte_len(1), BLOCK_SIZE);
+        assert_eq!(padded_byte_len(BLOCK_SIZE + 1), 2 * BLOCK_SIZE);
+    }
+
+    // ---- constants ----
+
+    #[test]
+    fn constant_relationships() {
+        assert_eq!(BLOCK_SIZE, 2880);
+        assert_eq!(CARD_SIZE, 80);
+        assert_eq!(CARDS_PER_BLOCK, 36);
+        assert_eq!(CARDS_PER_BLOCK * CARD_SIZE, BLOCK_SIZE);
+    }
+
+    // ---- header padding ----
+
+    #[test]
+    fn header_pad_full_block() {
+        let src = [0x41u8; BLOCK_SIZE]; // 'A' repeated
+        let mut dest = [0u8; BLOCK_SIZE];
+        pad_header_blocks(&mut dest, &src);
+        assert_eq!(&dest[..], &src[..]);
+    }
+
+    #[test]
+    fn header_pad_partial_block() {
+        let src = [0x41u8; 80]; // one card worth of 'A'
+        let mut dest = [0u8; BLOCK_SIZE];
+        pad_header_blocks(&mut dest, &src);
+        assert_eq!(&dest[..80], &src[..]);
+        // Remaining bytes should be ASCII space (0x20)
+        for &b in &dest[80..] {
+            assert_eq!(b, HEADER_PAD_BYTE);
+        }
+    }
+
+    #[test]
+    fn header_pad_empty() {
+        let src: &[u8] = &[];
+        let mut dest: [u8; 0] = [];
+        pad_header_blocks(&mut dest, src);
+        // No bytes to check, just verifying it doesn't panic.
+    }
+
+    #[test]
+    fn header_pad_multi_block() {
+        let src = [0x42u8; BLOCK_SIZE + 100];
+        let mut dest = [0u8; 2 * BLOCK_SIZE];
+        pad_header_blocks(&mut dest, &src);
+        assert_eq!(&dest[..BLOCK_SIZE + 100], &src[..]);
+        for &b in &dest[BLOCK_SIZE + 100..] {
+            assert_eq!(b, HEADER_PAD_BYTE);
+        }
+    }
+
+    // ---- data padding ----
+
+    #[test]
+    fn data_pad_full_block() {
+        let src = [0xFFu8; BLOCK_SIZE];
+        let mut dest = [0xAA; BLOCK_SIZE];
+        pad_data_blocks(&mut dest, &src);
+        assert_eq!(&dest[..], &src[..]);
+    }
+
+    #[test]
+    fn data_pad_partial_block() {
+        let src = [0xFFu8; 100];
+        let mut dest = [0xAA; BLOCK_SIZE];
+        pad_data_blocks(&mut dest, &src);
+        assert_eq!(&dest[..100], &src[..]);
+        for &b in &dest[100..] {
+            assert_eq!(b, DATA_PAD_BYTE);
+        }
+    }
+
+    #[test]
+    fn data_pad_empty() {
+        let src: &[u8] = &[];
+        let mut dest: [u8; 0] = [];
+        pad_data_blocks(&mut dest, src);
+    }
+
+    #[test]
+    fn data_pad_multi_block() {
+        let src = [0xABu8; BLOCK_SIZE + 500];
+        let mut dest = [0u8; 2 * BLOCK_SIZE];
+        pad_data_blocks(&mut dest, &src);
+        assert_eq!(&dest[..BLOCK_SIZE + 500], &src[..]);
+        for &b in &dest[BLOCK_SIZE + 500..] {
+            assert_eq!(b, DATA_PAD_BYTE);
+        }
+    }
+
+    // ---- read_block / write_block ----
+
+    #[test]
+    fn read_block_first() {
+        let mut data = [0u8; 2 * BLOCK_SIZE];
+        for (i, b) in data.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+        let mut block = [0u8; BLOCK_SIZE];
+        read_block(&mut block, &data, 0);
+        assert_eq!(&block[..], &data[..BLOCK_SIZE]);
+    }
+
+    #[test]
+    fn read_block_second() {
+        let mut data = [0u8; 2 * BLOCK_SIZE];
+        for (i, b) in data.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+        let mut block = [0u8; BLOCK_SIZE];
+        read_block(&mut block, &data, 1);
+        assert_eq!(&block[..], &data[BLOCK_SIZE..2 * BLOCK_SIZE]);
+    }
+
+    #[test]
+    #[should_panic(expected = "src does not contain block")]
+    fn read_block_out_of_bounds() {
+        let data = [0u8; BLOCK_SIZE];
+        let mut block = [0u8; BLOCK_SIZE];
+        read_block(&mut block, &data, 1);
+    }
+
+    #[test]
+    fn write_block_round_trip() {
+        let mut original = [0u8; BLOCK_SIZE];
+        for (i, b) in original.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+
+        let mut buffer = [0u8; 3 * BLOCK_SIZE];
+        write_block(&mut buffer, &original, 1);
+
+        let mut readback = [0u8; BLOCK_SIZE];
+        read_block(&mut readback, &buffer, 1);
+        assert_eq!(&readback[..], &original[..]);
+    }
+
+    #[test]
+    #[should_panic(expected = "dest does not have room for block")]
+    fn write_block_out_of_bounds() {
+        let block = [0u8; BLOCK_SIZE];
+        let mut dest = [0u8; BLOCK_SIZE];
+        write_block(&mut dest, &block, 1);
+    }
+
+    // ---- mismatched dest size panics ----
+
+    #[test]
+    #[should_panic(expected = "dest length must equal the padded block length")]
+    fn header_pad_wrong_dest_size() {
+        let src = [0u8; 100];
+        let mut dest = [0u8; 100]; // should be BLOCK_SIZE
+        pad_header_blocks(&mut dest, &src);
+    }
+
+    #[test]
+    #[should_panic(expected = "dest length must equal the padded block length")]
+    fn data_pad_wrong_dest_size() {
+        let src = [0u8; 100];
+        let mut dest = [0u8; 100]; // should be BLOCK_SIZE
+        pad_data_blocks(&mut dest, &src);
+    }
+}

--- a/crates/fitsio-pure/src/endian.rs
+++ b/crates/fitsio-pure/src/endian.rs
@@ -1,0 +1,773 @@
+//! Big-endian byte conversion for FITS data.
+//!
+//! FITS stores all binary data in big-endian (most-significant byte first) format.
+//! This module provides functions to read and write native Rust types from/to
+//! big-endian byte slices, plus bulk conversion routines for data arrays.
+
+/// Read a `u8` from the first byte of the slice.
+#[inline]
+pub fn read_u8(buf: &[u8]) -> u8 {
+    buf[0]
+}
+
+/// Read a big-endian `i16` from the first 2 bytes of the slice.
+#[inline]
+pub fn read_i16_be(buf: &[u8]) -> i16 {
+    i16::from_be_bytes([buf[0], buf[1]])
+}
+
+/// Read a big-endian `u16` from the first 2 bytes of the slice.
+#[inline]
+pub fn read_u16_be(buf: &[u8]) -> u16 {
+    u16::from_be_bytes([buf[0], buf[1]])
+}
+
+/// Read a big-endian `i32` from the first 4 bytes of the slice.
+#[inline]
+pub fn read_i32_be(buf: &[u8]) -> i32 {
+    i32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
+}
+
+/// Read a big-endian `u32` from the first 4 bytes of the slice.
+#[inline]
+pub fn read_u32_be(buf: &[u8]) -> u32 {
+    u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
+}
+
+/// Read a big-endian `i64` from the first 8 bytes of the slice.
+#[inline]
+pub fn read_i64_be(buf: &[u8]) -> i64 {
+    i64::from_be_bytes([
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+    ])
+}
+
+/// Read a big-endian `u64` from the first 8 bytes of the slice.
+#[inline]
+pub fn read_u64_be(buf: &[u8]) -> u64 {
+    u64::from_be_bytes([
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+    ])
+}
+
+/// Read a big-endian `f32` (IEEE 754) from the first 4 bytes of the slice.
+#[inline]
+pub fn read_f32_be(buf: &[u8]) -> f32 {
+    f32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]])
+}
+
+/// Read a big-endian `f64` (IEEE 754) from the first 8 bytes of the slice.
+#[inline]
+pub fn read_f64_be(buf: &[u8]) -> f64 {
+    f64::from_be_bytes([
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
+    ])
+}
+
+// --- Single-value writes ---
+
+/// Write a `u8` into the first byte of the slice.
+#[inline]
+pub fn write_u8(buf: &mut [u8], val: u8) {
+    buf[0] = val;
+}
+
+/// Write an `i16` in big-endian format into the first 2 bytes of the slice.
+#[inline]
+pub fn write_i16_be(buf: &mut [u8], val: i16) {
+    let bytes = val.to_be_bytes();
+    buf[0] = bytes[0];
+    buf[1] = bytes[1];
+}
+
+/// Write a `u16` in big-endian format into the first 2 bytes of the slice.
+#[inline]
+pub fn write_u16_be(buf: &mut [u8], val: u16) {
+    let bytes = val.to_be_bytes();
+    buf[0] = bytes[0];
+    buf[1] = bytes[1];
+}
+
+/// Write an `i32` in big-endian format into the first 4 bytes of the slice.
+#[inline]
+pub fn write_i32_be(buf: &mut [u8], val: i32) {
+    let bytes = val.to_be_bytes();
+    buf[..4].copy_from_slice(&bytes);
+}
+
+/// Write a `u32` in big-endian format into the first 4 bytes of the slice.
+#[inline]
+pub fn write_u32_be(buf: &mut [u8], val: u32) {
+    let bytes = val.to_be_bytes();
+    buf[..4].copy_from_slice(&bytes);
+}
+
+/// Write an `i64` in big-endian format into the first 8 bytes of the slice.
+#[inline]
+pub fn write_i64_be(buf: &mut [u8], val: i64) {
+    let bytes = val.to_be_bytes();
+    buf[..8].copy_from_slice(&bytes);
+}
+
+/// Write a `u64` in big-endian format into the first 8 bytes of the slice.
+#[inline]
+pub fn write_u64_be(buf: &mut [u8], val: u64) {
+    let bytes = val.to_be_bytes();
+    buf[..8].copy_from_slice(&bytes);
+}
+
+/// Write an `f32` in big-endian format into the first 4 bytes of the slice.
+#[inline]
+pub fn write_f32_be(buf: &mut [u8], val: f32) {
+    let bytes = val.to_be_bytes();
+    buf[..4].copy_from_slice(&bytes);
+}
+
+/// Write an `f64` in big-endian format into the first 8 bytes of the slice.
+#[inline]
+pub fn write_f64_be(buf: &mut [u8], val: f64) {
+    let bytes = val.to_be_bytes();
+    buf[..8].copy_from_slice(&bytes);
+}
+
+// --- Bulk conversions ---
+//
+// These convert a mutable byte buffer **in place** from big-endian to native
+// endianness for each element type. On big-endian platforms these are no-ops.
+// The buffer length must be a multiple of the element size.
+
+/// Convert a byte buffer of big-endian `i16` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 2.
+pub fn buf_i16_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(2),
+        "buffer length must be a multiple of 2"
+    );
+    for chunk in buf.chunks_exact_mut(2) {
+        let val = i16::from_be_bytes([chunk[0], chunk[1]]);
+        let native = val.to_ne_bytes();
+        chunk[0] = native[0];
+        chunk[1] = native[1];
+    }
+}
+
+/// Convert a byte buffer of big-endian `u16` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 2.
+pub fn buf_u16_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(2),
+        "buffer length must be a multiple of 2"
+    );
+    for chunk in buf.chunks_exact_mut(2) {
+        let val = u16::from_be_bytes([chunk[0], chunk[1]]);
+        let native = val.to_ne_bytes();
+        chunk[0] = native[0];
+        chunk[1] = native[1];
+    }
+}
+
+/// Convert a byte buffer of big-endian `i32` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 4.
+pub fn buf_i32_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(4),
+        "buffer length must be a multiple of 4"
+    );
+    for chunk in buf.chunks_exact_mut(4) {
+        let val = i32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+/// Convert a byte buffer of big-endian `u32` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 4.
+pub fn buf_u32_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(4),
+        "buffer length must be a multiple of 4"
+    );
+    for chunk in buf.chunks_exact_mut(4) {
+        let val = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+/// Convert a byte buffer of big-endian `i64` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 8.
+pub fn buf_i64_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(8),
+        "buffer length must be a multiple of 8"
+    );
+    for chunk in buf.chunks_exact_mut(8) {
+        let val = i64::from_be_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+/// Convert a byte buffer of big-endian `u64` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 8.
+pub fn buf_u64_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(8),
+        "buffer length must be a multiple of 8"
+    );
+    for chunk in buf.chunks_exact_mut(8) {
+        let val = u64::from_be_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+/// Convert a byte buffer of big-endian `f32` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 4.
+pub fn buf_f32_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(4),
+        "buffer length must be a multiple of 4"
+    );
+    for chunk in buf.chunks_exact_mut(4) {
+        let val = f32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+/// Convert a byte buffer of big-endian `f64` values to native endianness in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 8.
+pub fn buf_f64_be_to_native(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(8),
+        "buffer length must be a multiple of 8"
+    );
+    for chunk in buf.chunks_exact_mut(8) {
+        let val = f64::from_be_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        let native = val.to_ne_bytes();
+        chunk.copy_from_slice(&native);
+    }
+}
+
+// --- Bulk native-to-big-endian conversions ---
+
+/// Convert a byte buffer of native-endian `i16` values to big-endian in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 2.
+pub fn buf_i16_native_to_be(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(2),
+        "buffer length must be a multiple of 2"
+    );
+    for chunk in buf.chunks_exact_mut(2) {
+        let val = i16::from_ne_bytes([chunk[0], chunk[1]]);
+        let be = val.to_be_bytes();
+        chunk[0] = be[0];
+        chunk[1] = be[1];
+    }
+}
+
+/// Convert a byte buffer of native-endian `i32` values to big-endian in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 4.
+pub fn buf_i32_native_to_be(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(4),
+        "buffer length must be a multiple of 4"
+    );
+    for chunk in buf.chunks_exact_mut(4) {
+        let val = i32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let be = val.to_be_bytes();
+        chunk.copy_from_slice(&be);
+    }
+}
+
+/// Convert a byte buffer of native-endian `i64` values to big-endian in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 8.
+pub fn buf_i64_native_to_be(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(8),
+        "buffer length must be a multiple of 8"
+    );
+    for chunk in buf.chunks_exact_mut(8) {
+        let val = i64::from_ne_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        let be = val.to_be_bytes();
+        chunk.copy_from_slice(&be);
+    }
+}
+
+/// Convert a byte buffer of native-endian `f32` values to big-endian in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 4.
+pub fn buf_f32_native_to_be(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(4),
+        "buffer length must be a multiple of 4"
+    );
+    for chunk in buf.chunks_exact_mut(4) {
+        let val = f32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let be = val.to_be_bytes();
+        chunk.copy_from_slice(&be);
+    }
+}
+
+/// Convert a byte buffer of native-endian `f64` values to big-endian in place.
+///
+/// # Panics
+/// Panics if `buf.len()` is not a multiple of 8.
+pub fn buf_f64_native_to_be(buf: &mut [u8]) {
+    assert!(
+        buf.len().is_multiple_of(8),
+        "buffer length must be a multiple of 8"
+    );
+    for chunk in buf.chunks_exact_mut(8) {
+        let val = f64::from_ne_bytes([
+            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+        ]);
+        let be = val.to_be_bytes();
+        chunk.copy_from_slice(&be);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- read/write round-trip tests ---
+
+    #[test]
+    fn roundtrip_u8() {
+        let mut buf = [0u8; 1];
+        write_u8(&mut buf, 0xAB);
+        assert_eq!(read_u8(&buf), 0xAB);
+    }
+
+    #[test]
+    fn roundtrip_i16() {
+        let mut buf = [0u8; 2];
+        for val in [0_i16, 1, -1, i16::MIN, i16::MAX, 256, -256] {
+            write_i16_be(&mut buf, val);
+            assert_eq!(read_i16_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_u16() {
+        let mut buf = [0u8; 2];
+        for val in [0_u16, 1, u16::MAX, 256, 0xFF00] {
+            write_u16_be(&mut buf, val);
+            assert_eq!(read_u16_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_i32() {
+        let mut buf = [0u8; 4];
+        for val in [0_i32, 1, -1, i32::MIN, i32::MAX, 0x01020304, -0x01020304] {
+            write_i32_be(&mut buf, val);
+            assert_eq!(read_i32_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_u32() {
+        let mut buf = [0u8; 4];
+        for val in [0_u32, 1, u32::MAX, 0xDEADBEEF] {
+            write_u32_be(&mut buf, val);
+            assert_eq!(read_u32_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_i64() {
+        let mut buf = [0u8; 8];
+        for val in [0_i64, 1, -1, i64::MIN, i64::MAX] {
+            write_i64_be(&mut buf, val);
+            assert_eq!(read_i64_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_u64() {
+        let mut buf = [0u8; 8];
+        for val in [0_u64, 1, u64::MAX, 0xDEADBEEFCAFEBABE] {
+            write_u64_be(&mut buf, val);
+            assert_eq!(read_u64_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_f32() {
+        let mut buf = [0u8; 4];
+        for val in [
+            0.0_f32,
+            1.0,
+            -1.0,
+            f32::MIN,
+            f32::MAX,
+            f32::MIN_POSITIVE,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            core::f32::consts::PI,
+        ] {
+            write_f32_be(&mut buf, val);
+            assert_eq!(read_f32_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_f32_nan() {
+        let mut buf = [0u8; 4];
+        write_f32_be(&mut buf, f32::NAN);
+        assert!(read_f32_be(&buf).is_nan());
+    }
+
+    #[test]
+    fn roundtrip_f64() {
+        let mut buf = [0u8; 8];
+        for val in [
+            0.0_f64,
+            1.0,
+            -1.0,
+            f64::MIN,
+            f64::MAX,
+            f64::MIN_POSITIVE,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            core::f64::consts::PI,
+        ] {
+            write_f64_be(&mut buf, val);
+            assert_eq!(read_f64_be(&buf), val);
+        }
+    }
+
+    #[test]
+    fn roundtrip_f64_nan() {
+        let mut buf = [0u8; 8];
+        write_f64_be(&mut buf, f64::NAN);
+        assert!(read_f64_be(&buf).is_nan());
+    }
+
+    // --- Known byte sequence tests ---
+
+    #[test]
+    fn known_bytes_i16() {
+        assert_eq!(read_i16_be(&[0x00, 0x01]), 1_i16);
+        assert_eq!(read_i16_be(&[0xFF, 0xFF]), -1_i16);
+        assert_eq!(read_i16_be(&[0x80, 0x00]), i16::MIN);
+        assert_eq!(read_i16_be(&[0x7F, 0xFF]), i16::MAX);
+        assert_eq!(read_i16_be(&[0x01, 0x00]), 256_i16);
+    }
+
+    #[test]
+    fn known_bytes_u16() {
+        assert_eq!(read_u16_be(&[0x00, 0x01]), 1_u16);
+        assert_eq!(read_u16_be(&[0xFF, 0xFF]), u16::MAX);
+        assert_eq!(read_u16_be(&[0x00, 0x00]), 0_u16);
+    }
+
+    #[test]
+    fn known_bytes_i32() {
+        assert_eq!(read_i32_be(&[0x00, 0x00, 0x00, 0x01]), 1_i32);
+        assert_eq!(read_i32_be(&[0xFF, 0xFF, 0xFF, 0xFF]), -1_i32);
+        assert_eq!(read_i32_be(&[0x80, 0x00, 0x00, 0x00]), i32::MIN);
+        assert_eq!(read_i32_be(&[0x7F, 0xFF, 0xFF, 0xFF]), i32::MAX);
+    }
+
+    #[test]
+    fn known_bytes_i64() {
+        assert_eq!(
+            read_i64_be(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
+            1_i64
+        );
+        assert_eq!(
+            read_i64_be(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            -1_i64
+        );
+        assert_eq!(
+            read_i64_be(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            i64::MIN
+        );
+    }
+
+    #[test]
+    fn known_bytes_f32() {
+        // IEEE 754: 1.0f32 = 0x3F800000
+        assert_eq!(read_f32_be(&[0x3F, 0x80, 0x00, 0x00]), 1.0_f32);
+        // -1.0f32 = 0xBF800000
+        assert_eq!(read_f32_be(&[0xBF, 0x80, 0x00, 0x00]), -1.0_f32);
+        // 0.0f32 = 0x00000000
+        assert_eq!(read_f32_be(&[0x00, 0x00, 0x00, 0x00]), 0.0_f32);
+        // +inf = 0x7F800000
+        assert_eq!(read_f32_be(&[0x7F, 0x80, 0x00, 0x00]), f32::INFINITY);
+    }
+
+    #[test]
+    fn known_bytes_f64() {
+        // IEEE 754: 1.0f64 = 0x3FF0000000000000
+        assert_eq!(
+            read_f64_be(&[0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            1.0_f64
+        );
+        // -1.0f64 = 0xBFF0000000000000
+        assert_eq!(
+            read_f64_be(&[0xBF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            -1.0_f64
+        );
+    }
+
+    #[test]
+    fn write_known_bytes_i16() {
+        let mut buf = [0u8; 2];
+        write_i16_be(&mut buf, 1);
+        assert_eq!(buf, [0x00, 0x01]);
+        write_i16_be(&mut buf, -1);
+        assert_eq!(buf, [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn write_known_bytes_i32() {
+        let mut buf = [0u8; 4];
+        write_i32_be(&mut buf, 1);
+        assert_eq!(buf, [0x00, 0x00, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn write_known_bytes_f32() {
+        let mut buf = [0u8; 4];
+        write_f32_be(&mut buf, 1.0);
+        assert_eq!(buf, [0x3F, 0x80, 0x00, 0x00]);
+    }
+
+    // --- Bulk conversion tests ---
+
+    #[test]
+    fn bulk_i16_roundtrip() {
+        let values: [i16; 4] = [1, -1, i16::MIN, i16::MAX];
+        let mut buf = [0u8; 8];
+        for (i, &v) in values.iter().enumerate() {
+            write_i16_be(&mut buf[i * 2..], v);
+        }
+        let original = buf;
+
+        buf_i16_be_to_native(&mut buf);
+        buf_i16_native_to_be(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_i32_roundtrip() {
+        let values: [i32; 3] = [1, -1, i32::MAX];
+        let mut buf = [0u8; 12];
+        for (i, &v) in values.iter().enumerate() {
+            write_i32_be(&mut buf[i * 4..], v);
+        }
+        let original = buf;
+
+        buf_i32_be_to_native(&mut buf);
+        buf_i32_native_to_be(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_i64_roundtrip() {
+        let values: [i64; 2] = [i64::MIN, i64::MAX];
+        let mut buf = [0u8; 16];
+        for (i, &v) in values.iter().enumerate() {
+            write_i64_be(&mut buf[i * 8..], v);
+        }
+        let original = buf;
+
+        buf_i64_be_to_native(&mut buf);
+        buf_i64_native_to_be(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_f32_roundtrip() {
+        let values: [f32; 3] = [1.0, -1.0, core::f32::consts::PI];
+        let mut buf = [0u8; 12];
+        for (i, &v) in values.iter().enumerate() {
+            write_f32_be(&mut buf[i * 4..], v);
+        }
+        let original = buf;
+
+        buf_f32_be_to_native(&mut buf);
+        buf_f32_native_to_be(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_f64_roundtrip() {
+        let values: [f64; 2] = [f64::MIN, f64::MAX];
+        let mut buf = [0u8; 16];
+        for (i, &v) in values.iter().enumerate() {
+            write_f64_be(&mut buf[i * 8..], v);
+        }
+        let original = buf;
+
+        buf_f64_be_to_native(&mut buf);
+        buf_f64_native_to_be(&mut buf);
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_u16_roundtrip() {
+        let values: [u16; 3] = [0, 1, u16::MAX];
+        let mut buf = [0u8; 6];
+        for (i, &v) in values.iter().enumerate() {
+            write_u16_be(&mut buf[i * 2..], v);
+        }
+        let original = buf;
+
+        buf_u16_be_to_native(&mut buf);
+        // Convert back: read as native, write as big-endian
+        for chunk in buf.chunks_exact_mut(2) {
+            let val = u16::from_ne_bytes([chunk[0], chunk[1]]);
+            let be = val.to_be_bytes();
+            chunk[0] = be[0];
+            chunk[1] = be[1];
+        }
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_u32_roundtrip() {
+        let values: [u32; 2] = [0, u32::MAX];
+        let mut buf = [0u8; 8];
+        for (i, &v) in values.iter().enumerate() {
+            write_u32_be(&mut buf[i * 4..], v);
+        }
+        let original = buf;
+
+        buf_u32_be_to_native(&mut buf);
+        for chunk in buf.chunks_exact_mut(4) {
+            let val = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            let be = val.to_be_bytes();
+            chunk.copy_from_slice(&be);
+        }
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_u64_roundtrip() {
+        let values: [u64; 2] = [0, u64::MAX];
+        let mut buf = [0u8; 16];
+        for (i, &v) in values.iter().enumerate() {
+            write_u64_be(&mut buf[i * 8..], v);
+        }
+        let original = buf;
+
+        buf_u64_be_to_native(&mut buf);
+        for chunk in buf.chunks_exact_mut(8) {
+            let val = u64::from_ne_bytes([
+                chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+            ]);
+            let be = val.to_be_bytes();
+            chunk.copy_from_slice(&be);
+        }
+        assert_eq!(buf, original);
+    }
+
+    #[test]
+    fn bulk_empty_buffer() {
+        let mut empty: [u8; 0] = [];
+        buf_i16_be_to_native(&mut empty);
+        buf_i32_be_to_native(&mut empty);
+        buf_i64_be_to_native(&mut empty);
+        buf_f32_be_to_native(&mut empty);
+        buf_f64_be_to_native(&mut empty);
+    }
+
+    #[test]
+    #[should_panic(expected = "buffer length must be a multiple of 2")]
+    fn bulk_i16_odd_length_panics() {
+        let mut buf = [0u8; 3];
+        buf_i16_be_to_native(&mut buf);
+    }
+
+    #[test]
+    #[should_panic(expected = "buffer length must be a multiple of 4")]
+    fn bulk_i32_bad_length_panics() {
+        let mut buf = [0u8; 5];
+        buf_i32_be_to_native(&mut buf);
+    }
+
+    #[test]
+    #[should_panic(expected = "buffer length must be a multiple of 8")]
+    fn bulk_i64_bad_length_panics() {
+        let mut buf = [0u8; 7];
+        buf_i64_be_to_native(&mut buf);
+    }
+
+    #[test]
+    fn bulk_be_to_native_reads_correctly() {
+        let mut buf = [0u8; 8];
+        write_i16_be(&mut buf[0..], 100);
+        write_i16_be(&mut buf[2..], -200);
+        write_i16_be(&mut buf[4..], i16::MAX);
+        write_i16_be(&mut buf[6..], i16::MIN);
+
+        buf_i16_be_to_native(&mut buf);
+
+        assert_eq!(i16::from_ne_bytes([buf[0], buf[1]]), 100);
+        assert_eq!(i16::from_ne_bytes([buf[2], buf[3]]), -200);
+        assert_eq!(i16::from_ne_bytes([buf[4], buf[5]]), i16::MAX);
+        assert_eq!(i16::from_ne_bytes([buf[6], buf[7]]), i16::MIN);
+    }
+
+    #[test]
+    fn bulk_f32_be_to_native_reads_correctly() {
+        let mut buf = [0u8; 8];
+        write_f32_be(&mut buf[0..], 1.0);
+        write_f32_be(&mut buf[4..], -42.5);
+
+        buf_f32_be_to_native(&mut buf);
+
+        assert_eq!(
+            f32::from_ne_bytes([buf[0], buf[1], buf[2], buf[3]]),
+            1.0_f32
+        );
+        assert_eq!(
+            f32::from_ne_bytes([buf[4], buf[5], buf[6], buf[7]]),
+            -42.5_f32
+        );
+    }
+
+    #[test]
+    fn read_at_offset() {
+        let buf = [0x00, 0x00, 0x00, 0x01, 0x00, 0x02];
+        assert_eq!(read_i16_be(&buf[4..]), 2_i16);
+        assert_eq!(read_i32_be(&buf[0..]), 1_i32);
+    }
+}

--- a/crates/fitsio-pure/src/error.rs
+++ b/crates/fitsio-pure/src/error.rs
@@ -1,0 +1,150 @@
+/// All errors that can occur during FITS I/O operations.
+#[derive(Debug)]
+pub enum Error {
+    /// Malformed FITS header block.
+    InvalidHeader,
+    /// Premature end of data while reading.
+    UnexpectedEof,
+    /// Unrecognized BITPIX value.
+    InvalidBitpix(i64),
+    /// Malformed keyword name in a header card.
+    InvalidKeyword,
+    /// Unknown or unsupported XTENSION type.
+    UnsupportedExtension,
+    /// A header value could not be parsed correctly.
+    InvalidValue,
+    /// A required keyword was not found in the header.
+    MissingKeyword(&'static str),
+    /// An I/O error from the standard library.
+    #[cfg(feature = "std")]
+    Io(std::io::Error),
+}
+
+/// Convenience alias used throughout the crate.
+pub type Result<T> = core::result::Result<T, Error>;
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::InvalidHeader => write!(f, "invalid FITS header"),
+            Error::UnexpectedEof => write!(f, "unexpected end of file"),
+            Error::InvalidBitpix(v) => write!(f, "invalid BITPIX value: {v}"),
+            Error::InvalidKeyword => write!(f, "invalid keyword name"),
+            Error::UnsupportedExtension => write!(f, "unsupported XTENSION type"),
+            Error::InvalidValue => write!(f, "invalid header value"),
+            Error::MissingKeyword(kw) => write!(f, "missing required keyword: {kw}"),
+            #[cfg(feature = "std")]
+            Error::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_invalid_header() {
+        let e = Error::InvalidHeader;
+        assert_eq!(e.to_string(), "invalid FITS header");
+    }
+
+    #[test]
+    fn display_unexpected_eof() {
+        let e = Error::UnexpectedEof;
+        assert_eq!(e.to_string(), "unexpected end of file");
+    }
+
+    #[test]
+    fn display_invalid_bitpix() {
+        let e = Error::InvalidBitpix(-99);
+        assert_eq!(e.to_string(), "invalid BITPIX value: -99");
+    }
+
+    #[test]
+    fn display_invalid_keyword() {
+        let e = Error::InvalidKeyword;
+        assert_eq!(e.to_string(), "invalid keyword name");
+    }
+
+    #[test]
+    fn display_unsupported_extension() {
+        let e = Error::UnsupportedExtension;
+        assert_eq!(e.to_string(), "unsupported XTENSION type");
+    }
+
+    #[test]
+    fn display_invalid_value() {
+        let e = Error::InvalidValue;
+        assert_eq!(e.to_string(), "invalid header value");
+    }
+
+    #[test]
+    fn display_missing_keyword() {
+        let e = Error::MissingKeyword("NAXIS");
+        assert_eq!(e.to_string(), "missing required keyword: NAXIS");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn display_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let e = Error::Io(io_err);
+        assert_eq!(e.to_string(), "I/O error: file not found");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn io_error_from_conversion() {
+        let io_err = std::io::Error::other("oops");
+        let e: Error = io_err.into();
+        assert!(matches!(e, Error::Io(_)));
+    }
+
+    #[test]
+    fn result_type_alias() {
+        let ok: Result<u32> = Ok(42);
+        assert!(ok.is_ok());
+
+        let err: Result<u32> = Err(Error::InvalidHeader);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn debug_formatting() {
+        let e = Error::InvalidBitpix(99);
+        let debug = format!("{e:?}");
+        assert!(debug.contains("InvalidBitpix"));
+        assert!(debug.contains("99"));
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn std_error_source() {
+        use std::error::Error as StdError;
+
+        let e = Error::InvalidHeader;
+        assert!(e.source().is_none());
+
+        let io_err = std::io::Error::other("inner");
+        let e = Error::Io(io_err);
+        assert!(e.source().is_some());
+    }
+}

--- a/crates/fitsio-pure/src/io.rs
+++ b/crates/fitsio-pure/src/io.rs
@@ -1,0 +1,432 @@
+//! Trait abstractions for reading/writing FITS data in both `std` and `no_std` contexts.
+//!
+//! When the `std` feature is enabled, this module re-exports the standard library's
+//! I/O traits and types directly. In `no_std` mode, minimal equivalents are provided
+//! that support the subset of functionality required for FITS operations.
+
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+pub use std::io::{Cursor, Read, Result, Seek, SeekFrom, Write};
+
+// ── no_std: provide our own implementations ──
+
+#[cfg(not(feature = "std"))]
+mod nostd {
+    /// Minimal I/O error type for `no_std` environments.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum IoError {
+        /// An operation attempted to read or seek past the end of available data.
+        UnexpectedEof,
+        /// A write was attempted on a fixed-size buffer that has no remaining capacity.
+        WriteZero,
+        /// A seek landed on a negative absolute position.
+        InvalidSeek,
+    }
+
+    impl core::fmt::Display for IoError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                IoError::UnexpectedEof => write!(f, "unexpected end of file"),
+                IoError::WriteZero => write!(f, "write zero"),
+                IoError::InvalidSeek => write!(f, "invalid seek to negative position"),
+            }
+        }
+    }
+
+    /// Convenience result type that uses [`IoError`].
+    pub type Result<T> = core::result::Result<T, IoError>;
+
+    /// Describes a position to seek to within a stream.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SeekFrom {
+        /// Seek to an absolute byte offset from the start.
+        Start(u64),
+        /// Seek relative to the current position (may be negative).
+        Current(i64),
+        /// Seek relative to the end of the stream (may be negative).
+        End(i64),
+    }
+
+    /// Read bytes from a source.
+    pub trait Read {
+        /// Pull some bytes from this source into the specified buffer, returning
+        /// how many bytes were read.
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+
+        /// Read the exact number of bytes required to fill `buf`.
+        ///
+        /// Returns `Err(IoError::UnexpectedEof)` if the source runs out of data
+        /// before `buf` is completely filled.
+        fn read_exact(&mut self, buf: &mut [u8]) -> Result<()> {
+            let mut offset = 0;
+            while offset < buf.len() {
+                match self.read(&mut buf[offset..])? {
+                    0 => return Err(IoError::UnexpectedEof),
+                    n => offset += n,
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Write bytes to a destination.
+    pub trait Write {
+        /// Write a buffer into this writer, returning how many bytes were written.
+        fn write(&mut self, buf: &[u8]) -> Result<usize>;
+
+        /// Flush any buffered output.
+        fn flush(&mut self) -> Result<()>;
+
+        /// Attempt to write an entire buffer into this writer.
+        ///
+        /// Returns `Err(IoError::WriteZero)` if the writer cannot accept any more
+        /// bytes before the buffer is fully consumed.
+        fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+            let mut offset = 0;
+            while offset < buf.len() {
+                match self.write(&buf[offset..])? {
+                    0 => return Err(IoError::WriteZero),
+                    n => offset += n,
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Seek to a position within a stream.
+    pub trait Seek {
+        /// Seek to the given position, returning the new absolute offset from the
+        /// start of the stream.
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64>;
+    }
+
+    /// A cursor wrapping a byte buffer, providing [`Read`], [`Write`], and [`Seek`].
+    ///
+    /// This is the `no_std` equivalent of `std::io::Cursor`.
+    #[derive(Debug, Clone)]
+    pub struct Cursor<T> {
+        inner: T,
+        pos: u64,
+    }
+
+    impl<T> Cursor<T> {
+        /// Create a new cursor wrapping the given byte buffer.
+        pub fn new(inner: T) -> Self {
+            Cursor { inner, pos: 0 }
+        }
+
+        /// Return the current byte offset of the cursor.
+        pub fn position(&self) -> u64 {
+            self.pos
+        }
+
+        /// Set the cursor position.
+        pub fn set_position(&mut self, pos: u64) {
+            self.pos = pos;
+        }
+
+        /// Consume the cursor, returning the wrapped buffer.
+        pub fn into_inner(self) -> T {
+            self.inner
+        }
+
+        /// Borrow the wrapped buffer.
+        pub fn get_ref(&self) -> &T {
+            &self.inner
+        }
+
+        /// Mutably borrow the wrapped buffer.
+        pub fn get_mut(&mut self) -> &mut T {
+            &mut self.inner
+        }
+    }
+
+    // ── Read for Cursor<&[u8]> ──
+
+    impl Read for Cursor<&[u8]> {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            let start = self.pos as usize;
+            if start >= self.inner.len() {
+                return Ok(0);
+            }
+            let available = &self.inner[start..];
+            let n = buf.len().min(available.len());
+            buf[..n].copy_from_slice(&available[..n]);
+            self.pos += n as u64;
+            Ok(n)
+        }
+    }
+
+    // ── Seek helper ──
+
+    fn compute_seek_pos(current: u64, len: u64, from: SeekFrom) -> Result<u64> {
+        let new_pos: i64 = match from {
+            SeekFrom::Start(offset) => offset as i64,
+            SeekFrom::Current(offset) => current as i64 + offset,
+            SeekFrom::End(offset) => len as i64 + offset,
+        };
+        if new_pos < 0 {
+            return Err(IoError::InvalidSeek);
+        }
+        Ok(new_pos as u64)
+    }
+
+    // ── Seek for Cursor<&[u8]> ──
+
+    impl Seek for Cursor<&[u8]> {
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+            let new_pos = compute_seek_pos(self.pos, self.inner.len() as u64, pos)?;
+            self.pos = new_pos;
+            Ok(new_pos)
+        }
+    }
+
+    // ── Read / Write / Seek for Cursor<Vec<u8>> ──
+
+    extern crate alloc;
+
+    impl Read for Cursor<alloc::vec::Vec<u8>> {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            let start = self.pos as usize;
+            if start >= self.inner.len() {
+                return Ok(0);
+            }
+            let available = &self.inner[start..];
+            let n = buf.len().min(available.len());
+            buf[..n].copy_from_slice(&available[..n]);
+            self.pos += n as u64;
+            Ok(n)
+        }
+    }
+
+    impl Write for Cursor<alloc::vec::Vec<u8>> {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            let start = self.pos as usize;
+            // Extend if writing past the current end.
+            if start + buf.len() > self.inner.len() {
+                self.inner.resize(start + buf.len(), 0);
+            }
+            self.inner[start..start + buf.len()].copy_from_slice(buf);
+            self.pos += buf.len() as u64;
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Seek for Cursor<alloc::vec::Vec<u8>> {
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+            let new_pos = compute_seek_pos(self.pos, self.inner.len() as u64, pos)?;
+            self.pos = new_pos;
+            Ok(new_pos)
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub use nostd::*;
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_read_basic() {
+        let data = b"hello world";
+        let mut cursor = Cursor::new(&data[..]);
+        let mut buf = [0u8; 5];
+        let n = cursor.read(&mut buf).unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[test]
+    fn cursor_read_exact_success() {
+        let data = b"abcdef";
+        let mut cursor = Cursor::new(&data[..]);
+        let mut buf = [0u8; 6];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"abcdef");
+    }
+
+    #[test]
+    fn cursor_read_exact_short_read() {
+        let data = b"abc";
+        let mut cursor = Cursor::new(&data[..]);
+        let mut buf = [0u8; 6];
+        let result = cursor.read_exact(&mut buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn cursor_read_at_eof_returns_zero() {
+        let data = b"hi";
+        let mut cursor = Cursor::new(&data[..]);
+        let mut buf = [0u8; 10];
+        let _ = cursor.read(&mut buf).unwrap();
+        let n = cursor.read(&mut buf).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn cursor_seek_from_start() {
+        let data = b"abcdefgh";
+        let mut cursor = Cursor::new(&data[..]);
+        let pos = cursor.seek(SeekFrom::Start(3)).unwrap();
+        assert_eq!(pos, 3);
+        let mut buf = [0u8; 2];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"de");
+    }
+
+    #[test]
+    fn cursor_seek_from_current() {
+        let data = b"abcdefgh";
+        let mut cursor = Cursor::new(&data[..]);
+        cursor.seek(SeekFrom::Start(2)).unwrap();
+        let pos = cursor.seek(SeekFrom::Current(3)).unwrap();
+        assert_eq!(pos, 5);
+        let mut buf = [0u8; 1];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"f");
+    }
+
+    #[test]
+    fn cursor_seek_from_current_negative() {
+        let data = b"abcdefgh";
+        let mut cursor = Cursor::new(&data[..]);
+        cursor.seek(SeekFrom::Start(5)).unwrap();
+        let pos = cursor.seek(SeekFrom::Current(-2)).unwrap();
+        assert_eq!(pos, 3);
+        let mut buf = [0u8; 1];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"d");
+    }
+
+    #[test]
+    fn cursor_seek_from_end() {
+        let data = b"abcdefgh";
+        let mut cursor = Cursor::new(&data[..]);
+        let pos = cursor.seek(SeekFrom::End(-3)).unwrap();
+        assert_eq!(pos, 5);
+        let mut buf = [0u8; 3];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"fgh");
+    }
+
+    #[test]
+    fn cursor_seek_end_zero() {
+        let data = b"abcd";
+        let mut cursor = Cursor::new(&data[..]);
+        let pos = cursor.seek(SeekFrom::End(0)).unwrap();
+        assert_eq!(pos, 4);
+        let mut buf = [0u8; 1];
+        let n = cursor.read(&mut buf).unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn cursor_vec_write_and_read_back() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        cursor.write_all(b"fits data").unwrap();
+        cursor.seek(SeekFrom::Start(0)).unwrap();
+        let mut buf = [0u8; 9];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"fits data");
+    }
+
+    #[test]
+    fn cursor_vec_write_extends_buffer() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        cursor.write_all(b"hello").unwrap();
+        assert_eq!(cursor.get_ref().len(), 5);
+        cursor.write_all(b" world").unwrap();
+        assert_eq!(cursor.get_ref().len(), 11);
+        assert_eq!(cursor.get_ref(), b"hello world");
+    }
+
+    #[test]
+    fn cursor_vec_overwrite_middle() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        cursor.write_all(b"aaabbbccc").unwrap();
+        cursor.seek(SeekFrom::Start(3)).unwrap();
+        cursor.write_all(b"XXX").unwrap();
+        assert_eq!(cursor.get_ref(), b"aaaXXXccc");
+    }
+
+    #[test]
+    fn cursor_vec_seek_past_end_then_write() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        cursor.write_all(b"ab").unwrap();
+        cursor.seek(SeekFrom::Start(5)).unwrap();
+        cursor.write_all(b"c").unwrap();
+        assert_eq!(cursor.get_ref().len(), 6);
+        assert_eq!(cursor.get_ref()[0], b'a');
+        assert_eq!(cursor.get_ref()[1], b'b');
+        assert_eq!(cursor.get_ref()[2], 0);
+        assert_eq!(cursor.get_ref()[3], 0);
+        assert_eq!(cursor.get_ref()[4], 0);
+        assert_eq!(cursor.get_ref()[5], b'c');
+    }
+
+    #[test]
+    fn cursor_vec_flush_is_noop() {
+        let mut cursor = Cursor::new(Vec::<u8>::new());
+        cursor.flush().unwrap();
+    }
+
+    #[test]
+    fn cursor_position_tracking() {
+        let data = b"abcdef";
+        let mut cursor = Cursor::new(&data[..]);
+        assert_eq!(cursor.position(), 0);
+        let mut buf = [0u8; 3];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(cursor.position(), 3);
+        cursor.seek(SeekFrom::Start(1)).unwrap();
+        assert_eq!(cursor.position(), 1);
+    }
+
+    #[test]
+    fn cursor_into_inner() {
+        let data = vec![1u8, 2, 3];
+        let cursor = Cursor::new(data);
+        let inner = cursor.into_inner();
+        assert_eq!(inner, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn cursor_set_position() {
+        let data = b"abcdef";
+        let mut cursor = Cursor::new(&data[..]);
+        cursor.set_position(4);
+        assert_eq!(cursor.position(), 4);
+        let mut buf = [0u8; 2];
+        cursor.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ef");
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[test]
+    fn seek_to_negative_position_fails() {
+        let data = b"abc";
+        let mut cursor = Cursor::new(&data[..]);
+        let result = cursor.seek(SeekFrom::Current(-1));
+        assert!(result.is_err());
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[test]
+    fn io_error_display() {
+        let e = IoError::UnexpectedEof;
+        assert_eq!(format!("{e}"), "unexpected end of file");
+        let e = IoError::WriteZero;
+        assert_eq!(format!("{e}"), "write zero");
+        let e = IoError::InvalidSeek;
+        assert_eq!(format!("{e}"), "invalid seek to negative position");
+    }
+}

--- a/crates/fitsio-pure/src/lib.rs
+++ b/crates/fitsio-pure/src/lib.rs
@@ -1,23 +1,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// FITS block size in bytes.
-pub const BLOCK_SIZE: usize = 2880;
+extern crate alloc;
 
-/// FITS card (keyword record) size in bytes.
-pub const CARD_SIZE: usize = 80;
+pub mod block;
+pub mod endian;
+pub mod error;
+pub mod io;
+pub mod value;
 
-/// Number of cards per block.
-pub const CARDS_PER_BLOCK: usize = BLOCK_SIZE / CARD_SIZE;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn block_constants() {
-        assert_eq!(BLOCK_SIZE, 2880);
-        assert_eq!(CARD_SIZE, 80);
-        assert_eq!(CARDS_PER_BLOCK, 36);
-        assert_eq!(CARDS_PER_BLOCK * CARD_SIZE, BLOCK_SIZE);
-    }
-}
+pub use block::{BLOCK_SIZE, CARDS_PER_BLOCK, CARD_SIZE};
+pub use error::{Error, Result};

--- a/crates/fitsio-pure/src/value.rs
+++ b/crates/fitsio-pure/src/value.rs
@@ -1,0 +1,656 @@
+use alloc::string::String;
+use core::str;
+
+/// A parsed FITS header value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// FITS logical value (`T` or `F`).
+    Logical(bool),
+    /// FITS integer value.
+    Integer(i64),
+    /// FITS floating-point value.
+    Float(f64),
+    /// FITS character string (content between single quotes).
+    String(String),
+    /// FITS complex integer `(real, imaginary)`.
+    ComplexInt(i64, i64),
+    /// FITS complex float `(real, imaginary)`.
+    ComplexFloat(f64, f64),
+}
+
+/// Split a value field at the ` / ` comment separator.
+///
+/// Returns `(value_part, optional_comment)`. The comment does not include the
+/// leading ` / ` delimiter.
+fn split_comment(field: &[u8]) -> (&[u8], Option<&str>) {
+    // For string values the comment starts after the closing quote, so the
+    // caller must handle strings separately.  For non-string values we scan
+    // for ` / `.
+    let len = field.len();
+    let mut i = 0;
+    while i + 2 < len {
+        if field[i] == b' ' && field[i + 1] == b'/' && field[i + 2] == b' ' {
+            let value_part = &field[..i];
+            let comment = str::from_utf8(&field[i + 3..]).ok().map(|s| s.trim_end());
+            return (value_part, comment.filter(|s| !s.is_empty()));
+        }
+        i += 1;
+    }
+    (field, None)
+}
+
+/// Parse a FITS character-string value from the 70-byte value field.
+///
+/// String values begin with `'` at the first byte.  The string content
+/// continues until the closing `'` (doubled single-quotes `''` inside the
+/// string represent a literal `'`).  Everything after the closing quote is
+/// either whitespace or a ` / ` comment separator followed by the comment.
+fn parse_string(field: &[u8]) -> Option<(Value, Option<&str>)> {
+    if field.is_empty() || field[0] != b'\'' {
+        return None;
+    }
+
+    let mut value = String::new();
+    let mut i = 1; // skip opening quote
+    let len = field.len();
+
+    loop {
+        if i >= len {
+            // Unterminated string — be lenient and accept what we have.
+            break;
+        }
+        if field[i] == b'\'' {
+            if i + 1 < len && field[i + 1] == b'\'' {
+                // Doubled quote → literal single-quote.
+                value.push('\'');
+                i += 2;
+            } else {
+                // Closing quote.
+                i += 1;
+                break;
+            }
+        } else {
+            value.push(field[i] as char);
+            i += 1;
+        }
+    }
+
+    // Trim trailing spaces from the string value (FITS pads to min 8 chars).
+    let trimmed = value.trim_end().to_string();
+
+    // Look for comment after the closing quote.
+    let remainder = &field[i..];
+    let comment = find_comment_in_remainder(remainder);
+
+    Some((Value::String(trimmed), comment))
+}
+
+/// Given the bytes after a closing string quote, find the comment if present.
+fn find_comment_in_remainder(remainder: &[u8]) -> Option<&str> {
+    let len = remainder.len();
+    let mut i = 0;
+    while i + 2 < len {
+        if remainder[i] == b' ' && remainder[i + 1] == b'/' && remainder[i + 2] == b' ' {
+            let comment = str::from_utf8(&remainder[i + 3..])
+                .ok()
+                .map(|s| s.trim_end());
+            return comment.filter(|s| !s.is_empty());
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Try to parse a complex value `(real, imag)`.
+fn parse_complex(text: &str) -> Option<Value> {
+    let text = text.trim();
+    if !text.starts_with('(') || !text.ends_with(')') {
+        return None;
+    }
+    let inner = &text[1..text.len() - 1];
+    let comma_pos = inner.find(',')?;
+    let left = inner[..comma_pos].trim();
+    let right = inner[comma_pos + 1..].trim();
+
+    // Try integer complex first, then float complex.
+    if let (Ok(re), Ok(im)) = (left.parse::<i64>(), right.parse::<i64>()) {
+        // Only treat as integer complex if neither part looks like a float.
+        if !left.contains('.') && !right.contains('.') {
+            return Some(Value::ComplexInt(re, im));
+        }
+    }
+
+    let re = parse_float_str(left)?;
+    let im = parse_float_str(right)?;
+    Some(Value::ComplexFloat(re, im))
+}
+
+/// Parse a float string, handling FITS `D` exponent notation.
+fn parse_float_str(s: &str) -> Option<f64> {
+    let normalized = s.replace('D', "E").replace('d', "e");
+    normalized.parse::<f64>().ok()
+}
+
+/// Parse a FITS header value from the 70-byte value portion of an 80-byte
+/// card (bytes 10..80).
+///
+/// Returns the parsed [`Value`] and an optional comment string.
+///
+/// The caller is responsible for checking that bytes 8..10 of the card are
+/// `= ` (the value indicator) before calling this function.
+pub fn parse_value(value_bytes: &[u8]) -> Option<(Value, Option<&str>)> {
+    if value_bytes.is_empty() {
+        return None;
+    }
+
+    // 1. String values: first non-space byte is a single quote.
+    if value_bytes[0] == b'\'' {
+        return parse_string(value_bytes);
+    }
+
+    // For all other types, split off the comment first.
+    let (val_part, comment) = split_comment(value_bytes);
+
+    let val_text = str::from_utf8(val_part).ok()?.trim();
+    if val_text.is_empty() {
+        return None;
+    }
+
+    // 2. Logical: `T` or `F` — standard puts it in byte 30 of the card
+    //    (index 20 in the 70-byte field). We check both: if the trimmed text
+    //    is exactly `T` or `F`, or the canonical position holds the value.
+    if val_text == "T" {
+        return Some((Value::Logical(true), comment));
+    }
+    if val_text == "F" {
+        return Some((Value::Logical(false), comment));
+    }
+
+    // 3. Complex values: `(real, imag)`
+    if val_text.starts_with('(') {
+        if let Some(v) = parse_complex(val_text) {
+            return Some((v, comment));
+        }
+    }
+
+    // 4. Integer: no decimal point or exponent characters.
+    if !val_text.contains('.')
+        && !val_text.contains('E')
+        && !val_text.contains('e')
+        && !val_text.contains('D')
+        && !val_text.contains('d')
+    {
+        if let Ok(n) = val_text.parse::<i64>() {
+            return Some((Value::Integer(n), comment));
+        }
+    }
+
+    // 5. Float.
+    if let Some(f) = parse_float_str(val_text) {
+        return Some((Value::Float(f), comment));
+    }
+
+    None
+}
+
+/// Serialize a [`Value`] into a 70-byte field suitable for bytes 10..80 of an
+/// 80-byte FITS card.
+///
+/// Numeric and logical values are right-justified in the first 20 bytes
+/// (columns 11-30 of the card).  String values start at byte 0 with a single
+/// quote.
+pub fn format_value(value: &Value) -> [u8; 70] {
+    let mut buf = [b' '; 70];
+
+    match value {
+        Value::Logical(b) => {
+            // Standard: logical value in column 30 = index 20 of value field.
+            buf[19] = if *b { b'T' } else { b'F' };
+        }
+        Value::Integer(n) => {
+            let s = format_integer(*n);
+            right_justify(&s, &mut buf[..20]);
+        }
+        Value::Float(f) => {
+            let s = format_float(*f);
+            right_justify(&s, &mut buf[..20]);
+        }
+        Value::String(s) => {
+            write_string(s, &mut buf);
+        }
+        Value::ComplexInt(re, im) => {
+            let s = alloc::format!("({}, {})", re, im);
+            right_justify(s.as_bytes(), &mut buf[..30]);
+        }
+        Value::ComplexFloat(re, im) => {
+            let re_s = format_float_with_max(*re, 20);
+            let im_s = format_float_with_max(*im, 20);
+            let s = alloc::format!("({}, {})", re_s, im_s);
+            right_justify(s.as_bytes(), &mut buf[..50]);
+        }
+    }
+
+    buf
+}
+
+/// Right-justify `src` within `dest`, padding the left with spaces.
+fn right_justify(src: &[u8], dest: &mut [u8]) {
+    let len = src.len().min(dest.len());
+    let start = dest.len() - len;
+    // Fill with spaces first (already done by caller, but be safe).
+    for b in dest.iter_mut() {
+        *b = b' ';
+    }
+    dest[start..start + len].copy_from_slice(&src[..len]);
+}
+
+fn format_integer(n: i64) -> alloc::vec::Vec<u8> {
+    use alloc::format;
+    format!("{}", n).into_bytes()
+}
+
+fn format_float_raw(f: f64) -> alloc::string::String {
+    format_float_with_max(f, 20)
+}
+
+fn format_float_with_max(f: f64, max_len: usize) -> alloc::string::String {
+    use alloc::format;
+    if f == 0.0 {
+        return alloc::string::String::from("0.0");
+    }
+    // Start with high precision and reduce until the result fits.
+    let mut precision = 15usize;
+    loop {
+        let s = format!("{:.prec$E}", f, prec = precision);
+        if s.len() <= max_len || precision == 0 {
+            return s;
+        }
+        precision -= 1;
+    }
+}
+
+fn format_float(f: f64) -> alloc::vec::Vec<u8> {
+    format_float_raw(f).into_bytes()
+}
+
+fn write_string(s: &str, buf: &mut [u8; 70]) {
+    let mut pos = 0;
+    buf[pos] = b'\'';
+    pos += 1;
+
+    for ch in s.bytes() {
+        if pos >= 69 {
+            break; // Leave room for closing quote.
+        }
+        if ch == b'\'' {
+            if pos + 1 >= 69 {
+                break;
+            }
+            buf[pos] = b'\'';
+            buf[pos + 1] = b'\'';
+            pos += 2;
+        } else {
+            buf[pos] = ch;
+            pos += 1;
+        }
+    }
+
+    // Pad to minimum 8 characters between quotes (so closing quote at >= index 9).
+    while pos < 9 {
+        buf[pos] = b' ';
+        pos += 1;
+    }
+
+    if pos < 70 {
+        buf[pos] = b'\'';
+        // Remaining bytes stay as spaces.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: create a 70-byte field from a string, right-padded with spaces.
+    fn make_field(s: &str) -> [u8; 70] {
+        let mut buf = [b' '; 70];
+        let bytes = s.as_bytes();
+        let len = bytes.len().min(70);
+        buf[..len].copy_from_slice(&bytes[..len]);
+        buf
+    }
+
+    // ---- Logical ----
+
+    #[test]
+    fn parse_logical_true() {
+        let field = make_field("                   T");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Logical(true));
+        assert!(comment.is_none());
+    }
+
+    #[test]
+    fn parse_logical_false() {
+        let field = make_field("                   F");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Logical(false));
+        assert!(comment.is_none());
+    }
+
+    #[test]
+    fn parse_logical_with_comment() {
+        let field = make_field("                   T / this is a flag");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Logical(true));
+        assert_eq!(comment.unwrap(), "this is a flag");
+    }
+
+    // ---- Integer ----
+
+    #[test]
+    fn parse_integer_positive() {
+        let field = make_field("                  42");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Integer(42));
+        assert!(comment.is_none());
+    }
+
+    #[test]
+    fn parse_integer_negative() {
+        let field = make_field("                 -99");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Integer(-99));
+        assert!(comment.is_none());
+    }
+
+    #[test]
+    fn parse_integer_with_comment() {
+        let field = make_field("                1024 / block count");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Integer(1024));
+        assert_eq!(comment.unwrap(), "block count");
+    }
+
+    #[test]
+    fn parse_integer_zero() {
+        let field = make_field("                   0");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Integer(0));
+    }
+
+    // ---- Float ----
+
+    #[test]
+    fn parse_float_simple() {
+        let field = make_field("             9.80665");
+        let (val, _) = parse_value(&field).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - 9.80665).abs() < 1e-10),
+            other => panic!("Expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_float_scientific_e() {
+        let field = make_field("           1.234E+05");
+        let (val, _) = parse_value(&field).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - 1.234e5).abs() < 1e-5),
+            other => panic!("Expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_float_d_exponent() {
+        let field = make_field("           1.234D+05");
+        let (val, _) = parse_value(&field).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - 1.234e5).abs() < 1e-5),
+            other => panic!("Expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_float_negative_exponent() {
+        let field = make_field("          -2.5D-03");
+        let (val, _) = parse_value(&field).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - (-2.5e-3)).abs() < 1e-15),
+            other => panic!("Expected Float, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_float_with_comment() {
+        let field = make_field("               0.5 / scale factor");
+        let (val, comment) = parse_value(&field).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - 0.5).abs() < 1e-10),
+            other => panic!("Expected Float, got {:?}", other),
+        }
+        assert_eq!(comment.unwrap(), "scale factor");
+    }
+
+    // ---- String ----
+
+    #[test]
+    fn parse_string_simple() {
+        let field = make_field("'SIMPLE  '");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::String(String::from("SIMPLE")));
+    }
+
+    #[test]
+    fn parse_string_with_comment() {
+        let field = make_field("'IMAGE   '           / image type");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::String(String::from("IMAGE")));
+        assert_eq!(comment.unwrap(), "image type");
+    }
+
+    #[test]
+    fn parse_string_embedded_quotes() {
+        let field = make_field("'it''s ok'");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::String(String::from("it's ok")));
+    }
+
+    #[test]
+    fn parse_string_empty() {
+        let field = make_field("'        '");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::String(String::from("")));
+    }
+
+    #[test]
+    fn parse_string_min_padding() {
+        // String shorter than 8 chars, padded to 8.
+        let field = make_field("'AB      '");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::String(String::from("AB")));
+    }
+
+    // ---- Complex Integer ----
+
+    #[test]
+    fn parse_complex_int() {
+        let field = make_field("            (42, -7)");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::ComplexInt(42, -7));
+    }
+
+    #[test]
+    fn parse_complex_int_with_comment() {
+        let field = make_field("            (1, 2) / impedance");
+        let (val, comment) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::ComplexInt(1, 2));
+        assert_eq!(comment.unwrap(), "impedance");
+    }
+
+    // ---- Complex Float ----
+
+    #[test]
+    fn parse_complex_float() {
+        let field = make_field("       (1.5, -3.25)");
+        let (val, _) = parse_value(&field).unwrap();
+        match val {
+            Value::ComplexFloat(re, im) => {
+                assert!((re - 1.5).abs() < 1e-10);
+                assert!((im - (-3.25)).abs() < 1e-10);
+            }
+            other => panic!("Expected ComplexFloat, got {:?}", other),
+        }
+    }
+
+    // ---- Round-trip tests ----
+
+    #[test]
+    fn roundtrip_logical() {
+        for &b in &[true, false] {
+            let v = Value::Logical(b);
+            let buf = format_value(&v);
+            let (parsed, _) = parse_value(&buf).unwrap();
+            assert_eq!(parsed, v);
+        }
+    }
+
+    #[test]
+    fn roundtrip_integer() {
+        for &n in &[0i64, 1, -1, 42, -9999, i64::MAX, i64::MIN] {
+            let v = Value::Integer(n);
+            let buf = format_value(&v);
+            let (parsed, _) = parse_value(&buf).unwrap();
+            assert_eq!(parsed, v, "round-trip failed for {}", n);
+        }
+    }
+
+    #[test]
+    fn roundtrip_float() {
+        for &f in &[0.0f64, 1.0, -1.0, 9.80665, 1.23e10, -4.56e-20] {
+            let v = Value::Float(f);
+            let buf = format_value(&v);
+            let (parsed, _) = parse_value(&buf).unwrap();
+            match parsed {
+                Value::Float(pf) => {
+                    if f == 0.0 {
+                        assert_eq!(pf, 0.0);
+                    } else {
+                        let rel_err = ((pf - f) / f).abs();
+                        assert!(
+                            rel_err < 1e-10,
+                            "round-trip float failed: {} vs {} (rel err {})",
+                            f,
+                            pf,
+                            rel_err
+                        );
+                    }
+                }
+                other => panic!("Expected Float, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip_string() {
+        for s in &["HELLO", "", "it's here", "X", "A long string value"] {
+            let v = Value::String(String::from(*s));
+            let buf = format_value(&v);
+            let (parsed, _) = parse_value(&buf).unwrap();
+            assert_eq!(parsed, v, "round-trip failed for {:?}", s);
+        }
+    }
+
+    #[test]
+    fn roundtrip_complex_int() {
+        let v = Value::ComplexInt(10, -20);
+        let buf = format_value(&v);
+        let (parsed, _) = parse_value(&buf).unwrap();
+        assert_eq!(parsed, v);
+    }
+
+    #[test]
+    fn roundtrip_complex_float() {
+        let v = Value::ComplexFloat(1.5, -2.5);
+        let buf = format_value(&v);
+        let (parsed, _) = parse_value(&buf).unwrap();
+        match parsed {
+            Value::ComplexFloat(re, im) => {
+                assert!((re - 1.5).abs() < 1e-10);
+                assert!((im - (-2.5)).abs() < 1e-10);
+            }
+            other => panic!("Expected ComplexFloat, got {:?}", other),
+        }
+    }
+
+    // ---- Format tests ----
+
+    #[test]
+    fn format_logical_position() {
+        let buf = format_value(&Value::Logical(true));
+        // Logical should be at index 19 (column 30 of card).
+        assert_eq!(buf[19], b'T');
+        // Everything else should be spaces.
+        for (i, &b) in buf.iter().enumerate() {
+            if i != 19 {
+                assert_eq!(b, b' ', "non-space at index {}", i);
+            }
+        }
+    }
+
+    #[test]
+    fn format_integer_right_justified() {
+        let buf = format_value(&Value::Integer(42));
+        let first20 = core::str::from_utf8(&buf[..20]).unwrap();
+        assert_eq!(first20.trim(), "42");
+        // Check right-justification.
+        assert_eq!(buf[19], b'2');
+        assert_eq!(buf[18], b'4');
+    }
+
+    #[test]
+    fn format_string_quotes_and_padding() {
+        let buf = format_value(&Value::String(String::from("AB")));
+        // Should start with quote.
+        assert_eq!(buf[0], b'\'');
+        // Content.
+        assert_eq!(buf[1], b'A');
+        assert_eq!(buf[2], b'B');
+        // Padded to 8 chars, closing quote at index 9.
+        assert_eq!(buf[9], b'\'');
+    }
+
+    #[test]
+    fn format_string_embedded_quotes() {
+        let buf = format_value(&Value::String(String::from("it's")));
+        let s = core::str::from_utf8(&buf).unwrap();
+        // Should contain doubled quotes.
+        assert!(s.contains("it''s"), "Expected doubled quote in: {}", s);
+    }
+
+    // ---- Edge cases ----
+
+    #[test]
+    fn parse_empty_field_returns_none() {
+        assert!(parse_value(b"").is_none());
+    }
+
+    #[test]
+    fn parse_all_spaces_returns_none() {
+        let field = make_field("");
+        assert!(parse_value(&field).is_none());
+    }
+
+    #[test]
+    fn parse_large_integer() {
+        let field = make_field("       9999999999999");
+        let (val, _) = parse_value(&field).unwrap();
+        assert_eq!(val, Value::Integer(9999999999999));
+    }
+
+    #[test]
+    fn format_value_field_is_70_bytes() {
+        let buf = format_value(&Value::Integer(1));
+        assert_eq!(buf.len(), 70);
+    }
+}


### PR DESCRIPTION
## Summary
- **block.rs** — 2880-byte FITS block abstraction: constants, block count computation, header/data padding, block read/write
- **endian.rs** — Big-endian byte conversion for all FITS numeric types (i16/i32/i64/f32/f64 + unsigned), plus bulk buffer conversion
- **error.rs** — `Error` enum covering FITS parse/write failures, with `std::io::Error` wrapping behind `std` feature gate
- **value.rs** — `Value` enum (Logical, Integer, Float, String, ComplexInt, ComplexFloat) with parse/format for FITS header card values
- **io.rs** — `Read`/`Write`/`Seek`/`Cursor` trait re-exports for `std`, with full `no_std` equivalents

All modules are `no_std` compatible and the crate builds for `wasm32-unknown-unknown`. 124 tests total.

## Test plan
- [x] `cargo test --workspace` — 124 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build --target wasm32-unknown-unknown -p fitsio-pure` — builds