### PR TITLE
Layer 6: fitsio-compat crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,51 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fitsio-compat"
 version = "0.1.0"
 dependencies = [
  "fitsio-pure",
+ "tempfile",
 ]
 
 [[package]]
@@ -19,3 +60,395 @@ version = "0.1.0"
 dependencies = [
  "fitsio-pure",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/fitsio-compat/Cargo.toml
+++ b/crates/fitsio-compat/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 fitsio-pure = { path = "../fitsio-pure" }
+
+[dev-dependencies]
+tempfile = "3.25.0"

--- a/crates/fitsio-compat/src/errors.rs
+++ b/crates/fitsio-compat/src/errors.rs
@@ -1,0 +1,95 @@
+/// All errors that can occur in the fitsio-compat crate.
+#[derive(Debug)]
+pub enum Error {
+    /// An error from the fitsio-pure core library.
+    Fits(fitsio_pure::Error),
+    /// A standard I/O error.
+    Io(std::io::Error),
+    /// A free-form error message.
+    Message(String),
+}
+
+impl From<fitsio_pure::Error> for Error {
+    fn from(e: fitsio_pure::Error) -> Self {
+        Error::Fits(e)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Fits(e) => write!(f, "FITS error: {e}"),
+            Error::Io(e) => write!(f, "I/O error: {e}"),
+            Error::Message(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Fits(e) => Some(e),
+            Error::Io(e) => Some(e),
+            Error::Message(_) => None,
+        }
+    }
+}
+
+/// Convenience result type for the compat crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_fits_error() {
+        let e: Error = fitsio_pure::Error::InvalidHeader.into();
+        assert!(matches!(e, Error::Fits(fitsio_pure::Error::InvalidHeader)));
+    }
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let e: Error = io_err.into();
+        assert!(matches!(e, Error::Io(_)));
+    }
+
+    #[test]
+    fn display_fits_error() {
+        let e = Error::Fits(fitsio_pure::Error::InvalidHeader);
+        let s = e.to_string();
+        assert!(s.contains("FITS error"));
+    }
+
+    #[test]
+    fn display_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let e = Error::Io(io_err);
+        let s = e.to_string();
+        assert!(s.contains("I/O error"));
+    }
+
+    #[test]
+    fn display_message() {
+        let e = Error::Message("something went wrong".into());
+        assert_eq!(e.to_string(), "something went wrong");
+    }
+
+    #[test]
+    fn error_source() {
+        use std::error::Error as StdError;
+
+        let e = Error::Message("msg".into());
+        assert!(e.source().is_none());
+
+        let e = Error::Fits(fitsio_pure::Error::InvalidHeader);
+        assert!(e.source().is_some());
+    }
+}

--- a/crates/fitsio-compat/src/fitsfile.rs
+++ b/crates/fitsio-compat/src/fitsfile.rs
@@ -1,0 +1,386 @@
+use std::path::{Path, PathBuf};
+
+use crate::errors::{Error, Result};
+use crate::hdu::FitsHdu;
+use crate::images::ImageDescription;
+
+/// Whether a file is opened for reading or writing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileOpenMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// An in-memory representation of an open FITS file.
+#[derive(Debug)]
+pub struct FitsFile {
+    data: Vec<u8>,
+    filename: PathBuf,
+    mode: FileOpenMode,
+}
+
+/// Builder for creating a new FITS file.
+pub struct NewFitsFile {
+    path: PathBuf,
+    overwrite: bool,
+}
+
+/// Trait for types that can identify an HDU (by index or name).
+pub trait DescribesHdu {
+    fn get_hdu<'a>(
+        &self,
+        fits_data: &'a fitsio_pure::hdu::FitsData,
+    ) -> Option<(usize, &'a fitsio_pure::hdu::Hdu)>;
+}
+
+impl DescribesHdu for usize {
+    fn get_hdu<'a>(
+        &self,
+        fits_data: &'a fitsio_pure::hdu::FitsData,
+    ) -> Option<(usize, &'a fitsio_pure::hdu::Hdu)> {
+        fits_data.get(*self).map(|hdu| (*self, hdu))
+    }
+}
+
+impl DescribesHdu for &str {
+    fn get_hdu<'a>(
+        &self,
+        fits_data: &'a fitsio_pure::hdu::FitsData,
+    ) -> Option<(usize, &'a fitsio_pure::hdu::Hdu)> {
+        for (i, hdu) in fits_data.iter().enumerate() {
+            for card in &hdu.cards {
+                if card.keyword_str() == "EXTNAME" {
+                    if let Some(fitsio_pure::value::Value::String(ref s)) = card.value {
+                        if s.trim() == *self {
+                            return Some((i, hdu));
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+impl DescribesHdu for String {
+    fn get_hdu<'a>(
+        &self,
+        fits_data: &'a fitsio_pure::hdu::FitsData,
+    ) -> Option<(usize, &'a fitsio_pure::hdu::Hdu)> {
+        self.as_str().get_hdu(fits_data)
+    }
+}
+
+impl FitsFile {
+    /// Open an existing FITS file in read-only mode.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let data = std::fs::read(path.as_ref())?;
+        Ok(FitsFile {
+            data,
+            filename: path.as_ref().to_path_buf(),
+            mode: FileOpenMode::ReadOnly,
+        })
+    }
+
+    /// Open an existing FITS file for editing.
+    pub fn edit<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let data = std::fs::read(path.as_ref())?;
+        Ok(FitsFile {
+            data,
+            filename: path.as_ref().to_path_buf(),
+            mode: FileOpenMode::ReadWrite,
+        })
+    }
+
+    /// Return a builder for creating a new FITS file.
+    pub fn create<P: AsRef<Path>>(path: P) -> NewFitsFile {
+        NewFitsFile {
+            path: path.as_ref().to_path_buf(),
+            overwrite: false,
+        }
+    }
+
+    /// Return a handle to the primary HDU (index 0).
+    pub fn primary_hdu(&self) -> Result<FitsHdu> {
+        Ok(FitsHdu { hdu_index: 0 })
+    }
+
+    /// Return a handle to the HDU described by `desc` (index or name).
+    pub fn hdu<D: DescribesHdu>(&self, desc: D) -> Result<FitsHdu> {
+        let fits_data = fitsio_pure::hdu::parse_fits(&self.data)?;
+        let (idx, _) = desc
+            .get_hdu(&fits_data)
+            .ok_or(Error::Message("HDU not found".to_string()))?;
+        Ok(FitsHdu { hdu_index: idx })
+    }
+
+    /// Return the number of HDUs in this file.
+    pub fn num_hdus(&self) -> Result<usize> {
+        let fits_data = fitsio_pure::hdu::parse_fits(&self.data)?;
+        Ok(fits_data.len())
+    }
+
+    /// Return handles to all HDUs in the file.
+    pub fn iter(&self) -> Result<Vec<FitsHdu>> {
+        let fits_data = fitsio_pure::hdu::parse_fits(&self.data)?;
+        Ok((0..fits_data.len())
+            .map(|i| FitsHdu { hdu_index: i })
+            .collect())
+    }
+
+    /// Create a new image extension HDU with the given name and description.
+    pub fn create_image(&mut self, extname: &str, desc: &ImageDescription) -> Result<FitsHdu> {
+        let bitpix = desc.data_type.to_bitpix();
+        let naxes = &desc.dimensions;
+
+        let mut cards = fitsio_pure::extension::build_extension_header(
+            fitsio_pure::extension::ExtensionType::Image,
+            bitpix,
+            naxes,
+            0,
+            1,
+        )?;
+
+        let extname_card = fitsio_pure::header::Card {
+            keyword: make_keyword("EXTNAME"),
+            value: Some(fitsio_pure::value::Value::String(extname.to_string())),
+            comment: None,
+        };
+        cards.push(extname_card);
+
+        let header_bytes = fitsio_pure::header::serialize_header(&cards);
+
+        let data_bytes = desc.dimensions.iter().copied().product::<usize>()
+            * ((bitpix.unsigned_abs() as usize) / 8);
+        let padded_data = fitsio_pure::block::padded_byte_len(data_bytes);
+
+        self.data.extend_from_slice(&header_bytes);
+        self.data.resize(self.data.len() + padded_data, 0u8);
+
+        let fits_data = fitsio_pure::hdu::parse_fits(&self.data)?;
+        let idx = fits_data.len() - 1;
+        Ok(FitsHdu { hdu_index: idx })
+    }
+
+    /// Create a new binary table extension HDU.
+    pub fn create_table(
+        &mut self,
+        extname: &str,
+        columns: &[fitsio_pure::bintable::BinaryColumnDescriptor],
+    ) -> Result<FitsHdu> {
+        let mut cards = fitsio_pure::bintable::build_binary_table_cards(columns, 0, 0)?;
+
+        let extname_card = fitsio_pure::header::Card {
+            keyword: make_keyword("EXTNAME"),
+            value: Some(fitsio_pure::value::Value::String(extname.to_string())),
+            comment: None,
+        };
+        cards.push(extname_card);
+
+        let header_bytes = fitsio_pure::header::serialize_header(&cards);
+        self.data.extend_from_slice(&header_bytes);
+
+        let fits_data = fitsio_pure::hdu::parse_fits(&self.data)?;
+        let idx = fits_data.len() - 1;
+        Ok(FitsHdu { hdu_index: idx })
+    }
+
+    /// Return a reference to the in-memory FITS bytes.
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Replace the in-memory FITS bytes (used by write operations).
+    pub fn set_data(&mut self, data: Vec<u8>) {
+        self.data = data;
+    }
+
+    /// Flush the in-memory data to disk if opened for writing.
+    pub fn flush(&self) -> Result<()> {
+        if self.mode == FileOpenMode::ReadWrite {
+            std::fs::write(&self.filename, &self.data)?;
+        }
+        Ok(())
+    }
+
+    /// Return the file path.
+    pub fn filename(&self) -> &Path {
+        &self.filename
+    }
+
+    /// Return the open mode.
+    pub fn mode(&self) -> FileOpenMode {
+        self.mode
+    }
+}
+
+impl Drop for FitsFile {
+    fn drop(&mut self) {
+        if self.mode == FileOpenMode::ReadWrite {
+            let _ = std::fs::write(&self.filename, &self.data);
+        }
+    }
+}
+
+impl NewFitsFile {
+    /// Set whether to overwrite an existing file.
+    pub fn overwrite(mut self) -> Self {
+        self.overwrite = true;
+        self
+    }
+
+    /// Finalize creation: write a minimal primary HDU and return an open `FitsFile`.
+    pub fn open(self) -> Result<FitsFile> {
+        if !self.overwrite && self.path.exists() {
+            return Err(Error::Message(format!(
+                "file already exists: {}",
+                self.path.display()
+            )));
+        }
+
+        let cards = fitsio_pure::primary::build_primary_header(8, &[])?;
+        let header_bytes = fitsio_pure::header::serialize_header(&cards);
+
+        std::fs::write(&self.path, &header_bytes)?;
+
+        Ok(FitsFile {
+            data: header_bytes,
+            filename: self.path,
+            mode: FileOpenMode::ReadWrite,
+        })
+    }
+}
+
+fn make_keyword(name: &str) -> [u8; 8] {
+    let mut kw = [b' '; 8];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(8);
+    kw[..len].copy_from_slice(&bytes[..len]);
+    kw
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::images::ImageType;
+
+    #[test]
+    fn create_and_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        assert_eq!(f.mode(), FileOpenMode::ReadWrite);
+        assert!(f.data().len() >= 2880);
+    }
+
+    #[test]
+    fn create_exists_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        FitsFile::create(&path).open().unwrap();
+        assert!(FitsFile::create(&path).open().is_err());
+    }
+
+    #[test]
+    fn create_with_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        FitsFile::create(&path).open().unwrap();
+        FitsFile::create(&path).overwrite().open().unwrap();
+    }
+
+    #[test]
+    fn open_readonly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        FitsFile::create(&path).open().unwrap();
+        let f = FitsFile::open(&path).unwrap();
+        assert_eq!(f.mode(), FileOpenMode::ReadOnly);
+    }
+
+    #[test]
+    fn edit_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        FitsFile::create(&path).open().unwrap();
+        let f = FitsFile::edit(&path).unwrap();
+        assert_eq!(f.mode(), FileOpenMode::ReadWrite);
+    }
+
+    #[test]
+    fn primary_hdu() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        assert_eq!(hdu.hdu_index, 0);
+    }
+
+    #[test]
+    fn num_hdus() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        assert_eq!(f.num_hdus().unwrap(), 1);
+    }
+
+    #[test]
+    fn create_image_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![10, 10],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        assert_eq!(hdu.hdu_index, 1);
+        assert_eq!(f.num_hdus().unwrap(), 2);
+    }
+
+    #[test]
+    fn hdu_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![10],
+        };
+        f.create_image("SCI", &desc).unwrap();
+        let hdu = f.hdu("SCI").unwrap();
+        assert_eq!(hdu.hdu_index, 1);
+    }
+
+    #[test]
+    fn hdu_by_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.hdu(0usize).unwrap();
+        assert_eq!(hdu.hdu_index, 0);
+    }
+
+    #[test]
+    fn hdu_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        assert!(f.hdu("MISSING").is_err());
+    }
+
+    #[test]
+    fn iter_hdus() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let desc = ImageDescription {
+            data_type: ImageType::Short,
+            dimensions: vec![5],
+        };
+        f.create_image("EXT1", &desc).unwrap();
+        f.create_image("EXT2", &desc).unwrap();
+        let hdus = f.iter().unwrap();
+        assert_eq!(hdus.len(), 3);
+    }
+}

--- a/crates/fitsio-compat/src/hdu.rs
+++ b/crates/fitsio-compat/src/hdu.rs
@@ -1,0 +1,113 @@
+use crate::errors::{Error, Result};
+use crate::fitsfile::FitsFile;
+use crate::headers::{ReadsKey, WritesKey};
+
+/// Lightweight handle to one HDU within a FITS file.
+///
+/// This stores only the index; the underlying data is always accessed
+/// through the `FitsFile`.
+#[derive(Debug, Clone)]
+pub struct FitsHdu {
+    pub(crate) hdu_index: usize,
+}
+
+/// Describes the kind and shape of data stored in an HDU.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HduInfo {
+    ImageInfo {
+        shape: Vec<usize>,
+        image_type: crate::images::ImageType,
+    },
+    TableInfo {
+        column_count: usize,
+        row_count: usize,
+    },
+    AnyInfo,
+}
+
+impl FitsHdu {
+    /// Read a header keyword value from this HDU.
+    pub fn read_key<T: ReadsKey>(&self, file: &FitsFile, name: &str) -> Result<T> {
+        T::read_key(file, self, name)
+    }
+
+    /// Write a header keyword value to this HDU.
+    pub fn write_key<T: WritesKey>(
+        &self,
+        file: &mut FitsFile,
+        name: &str,
+        value: &T,
+    ) -> Result<()> {
+        T::write_key(file, self, name, value)
+    }
+
+    /// Return information about the type and shape of data in this HDU.
+    pub fn info(&self, file: &FitsFile) -> Result<HduInfo> {
+        let fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+        let hdu = fits_data.get(self.hdu_index).ok_or(Error::Message(format!(
+            "HDU index {} out of range",
+            self.hdu_index
+        )))?;
+
+        match &hdu.info {
+            fitsio_pure::hdu::HduInfo::Primary { bitpix, naxes } => {
+                let image_type = crate::images::ImageType::from_bitpix(*bitpix)?;
+                Ok(HduInfo::ImageInfo {
+                    shape: naxes.clone(),
+                    image_type,
+                })
+            }
+            fitsio_pure::hdu::HduInfo::Image { bitpix, naxes } => {
+                let image_type = crate::images::ImageType::from_bitpix(*bitpix)?;
+                Ok(HduInfo::ImageInfo {
+                    shape: naxes.clone(),
+                    image_type,
+                })
+            }
+            fitsio_pure::hdu::HduInfo::AsciiTable {
+                naxis2, tfields, ..
+            } => Ok(HduInfo::TableInfo {
+                column_count: *tfields,
+                row_count: *naxis2,
+            }),
+            fitsio_pure::hdu::HduInfo::BinaryTable {
+                naxis2, tfields, ..
+            } => Ok(HduInfo::TableInfo {
+                column_count: *tfields,
+                row_count: *naxis2,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fitsfile::FitsFile;
+
+    #[test]
+    fn hdu_info_primary_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        let info = hdu.info(&f).unwrap();
+        match info {
+            HduInfo::ImageInfo { shape, .. } => {
+                assert!(shape.is_empty());
+            }
+            _ => panic!("Expected ImageInfo"),
+        }
+    }
+
+    #[test]
+    fn hdu_read_write_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        hdu.write_key(&mut f, "TESTVAL", &42i64).unwrap();
+        let val: i64 = hdu.read_key(&f, "TESTVAL").unwrap();
+        assert_eq!(val, 42);
+    }
+}

--- a/crates/fitsio-compat/src/headers.rs
+++ b/crates/fitsio-compat/src/headers.rs
@@ -1,0 +1,253 @@
+use crate::errors::{Error, Result};
+use crate::fitsfile::FitsFile;
+use crate::hdu::FitsHdu;
+
+/// A header value with an optional comment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HeaderValue<T> {
+    pub value: T,
+    pub comment: Option<String>,
+}
+
+/// Trait for types that can be read from a FITS header card.
+pub trait ReadsKey: Sized {
+    fn read_key(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Self>;
+}
+
+/// Trait for types that can be written to a FITS header card.
+pub trait WritesKey {
+    fn write_key(file: &mut FitsFile, hdu: &FitsHdu, name: &str, value: &Self) -> Result<()>;
+}
+
+fn find_card_value(
+    file: &FitsFile,
+    hdu: &FitsHdu,
+    name: &str,
+) -> Result<fitsio_pure::value::Value> {
+    let fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+    let core_hdu = fits_data.get(hdu.hdu_index).ok_or(Error::Message(format!(
+        "HDU index {} not found",
+        hdu.hdu_index
+    )))?;
+
+    for card in &core_hdu.cards {
+        if card.keyword_str() == name {
+            if let Some(ref v) = card.value {
+                return Ok(v.clone());
+            }
+        }
+    }
+    Err(Error::Message(format!("keyword '{name}' not found")))
+}
+
+impl ReadsKey for i64 {
+    fn read_key(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Self> {
+        match find_card_value(file, hdu, name)? {
+            fitsio_pure::value::Value::Integer(n) => Ok(n),
+            _ => Err(Error::Message(format!(
+                "keyword '{name}' is not an integer"
+            ))),
+        }
+    }
+}
+
+impl ReadsKey for f64 {
+    fn read_key(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Self> {
+        match find_card_value(file, hdu, name)? {
+            fitsio_pure::value::Value::Float(f) => Ok(f),
+            fitsio_pure::value::Value::Integer(n) => Ok(n as f64),
+            _ => Err(Error::Message(format!("keyword '{name}' is not a float"))),
+        }
+    }
+}
+
+impl ReadsKey for bool {
+    fn read_key(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Self> {
+        match find_card_value(file, hdu, name)? {
+            fitsio_pure::value::Value::Logical(b) => Ok(b),
+            _ => Err(Error::Message(format!("keyword '{name}' is not a logical"))),
+        }
+    }
+}
+
+impl ReadsKey for String {
+    fn read_key(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Self> {
+        match find_card_value(file, hdu, name)? {
+            fitsio_pure::value::Value::String(s) => Ok(s.trim().to_string()),
+            _ => Err(Error::Message(format!("keyword '{name}' is not a string"))),
+        }
+    }
+}
+
+fn make_keyword(name: &str) -> [u8; 8] {
+    let mut kw = [b' '; 8];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(8);
+    kw[..len].copy_from_slice(&bytes[..len]);
+    kw
+}
+
+fn write_key_to_file(
+    file: &mut FitsFile,
+    hdu: &FitsHdu,
+    name: &str,
+    value: fitsio_pure::value::Value,
+) -> Result<()> {
+    let mut fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+    let core_hdu = fits_data
+        .hdus
+        .get_mut(hdu.hdu_index)
+        .ok_or(Error::Message(format!(
+            "HDU index {} not found",
+            hdu.hdu_index
+        )))?;
+
+    let keyword = make_keyword(name);
+    let mut found = false;
+    for card in &mut core_hdu.cards {
+        if card.keyword_str() == name {
+            card.value = Some(value.clone());
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        let end_idx = core_hdu.cards.iter().position(|c| c.is_end());
+        let new_card = fitsio_pure::header::Card {
+            keyword,
+            value: Some(value),
+            comment: None,
+        };
+        if let Some(idx) = end_idx {
+            core_hdu.cards.insert(idx, new_card);
+        } else {
+            core_hdu.cards.push(new_card);
+        }
+    }
+
+    rebuild_fits_data(file, &fits_data)
+}
+
+fn rebuild_fits_data(file: &mut FitsFile, fits_data: &fitsio_pure::hdu::FitsData) -> Result<()> {
+    let mut new_data = Vec::new();
+
+    for (i, hdu) in fits_data.hdus.iter().enumerate() {
+        let cards_without_end: Vec<_> = hdu.cards.iter().filter(|c| !c.is_end()).cloned().collect();
+        let header_bytes = fitsio_pure::header::serialize_header(&cards_without_end);
+        new_data.extend_from_slice(&header_bytes);
+
+        if hdu.data_len > 0 {
+            let data_end = hdu.data_start + hdu.data_len;
+            if data_end <= file.data().len() {
+                let raw = &file.data()[hdu.data_start..data_end];
+                let padded_len = fitsio_pure::block::padded_byte_len(raw.len());
+                new_data.extend_from_slice(raw);
+                new_data.resize(new_data.len() + (padded_len - raw.len()), 0);
+            }
+        }
+
+        let _ = i;
+    }
+
+    file.set_data(new_data);
+    Ok(())
+}
+
+impl WritesKey for i64 {
+    fn write_key(file: &mut FitsFile, hdu: &FitsHdu, name: &str, value: &Self) -> Result<()> {
+        write_key_to_file(file, hdu, name, fitsio_pure::value::Value::Integer(*value))
+    }
+}
+
+impl WritesKey for f64 {
+    fn write_key(file: &mut FitsFile, hdu: &FitsHdu, name: &str, value: &Self) -> Result<()> {
+        write_key_to_file(file, hdu, name, fitsio_pure::value::Value::Float(*value))
+    }
+}
+
+impl WritesKey for bool {
+    fn write_key(file: &mut FitsFile, hdu: &FitsHdu, name: &str, value: &Self) -> Result<()> {
+        write_key_to_file(file, hdu, name, fitsio_pure::value::Value::Logical(*value))
+    }
+}
+
+impl WritesKey for String {
+    fn write_key(file: &mut FitsFile, hdu: &FitsHdu, name: &str, value: &Self) -> Result<()> {
+        write_key_to_file(
+            file,
+            hdu,
+            name,
+            fitsio_pure::value::Value::String(value.clone()),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fitsfile::FitsFile;
+
+    #[test]
+    fn read_write_integer_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        i64::write_key(&mut f, &hdu, "TESTKEY", &42).unwrap();
+        let val = i64::read_key(&f, &hdu, "TESTKEY").unwrap();
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    fn read_write_float_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        f64::write_key(&mut f, &hdu, "FLTKEY", &3.125).unwrap();
+        let val = f64::read_key(&f, &hdu, "FLTKEY").unwrap();
+        assert!((val - 3.125).abs() < 1e-10);
+    }
+
+    #[test]
+    fn read_write_bool_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        bool::write_key(&mut f, &hdu, "FLAG", &true).unwrap();
+        let val = bool::read_key(&f, &hdu, "FLAG").unwrap();
+        assert!(val);
+    }
+
+    #[test]
+    fn read_write_string_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        String::write_key(&mut f, &hdu, "OBJECT", &"NGC 1234".to_string()).unwrap();
+        let val = String::read_key(&f, &hdu, "OBJECT").unwrap();
+        assert_eq!(val, "NGC 1234");
+    }
+
+    #[test]
+    fn read_missing_key_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        let f = FitsFile::create(&path).open().unwrap();
+        let hdu = f.primary_hdu().unwrap();
+        assert!(i64::read_key(&f, &hdu, "MISSING").is_err());
+    }
+
+    #[test]
+    fn header_value_struct() {
+        let hv = HeaderValue {
+            value: 42i64,
+            comment: Some("the answer".to_string()),
+        };
+        assert_eq!(hv.value, 42);
+        assert_eq!(hv.comment.as_deref(), Some("the answer"));
+    }
+}

--- a/crates/fitsio-compat/src/images.rs
+++ b/crates/fitsio-compat/src/images.rs
@@ -1,0 +1,359 @@
+use crate::errors::{Error, Result};
+use crate::fitsfile::FitsFile;
+use crate::hdu::FitsHdu;
+
+/// Describes the shape and type of an image HDU.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageDescription {
+    pub data_type: ImageType,
+    pub dimensions: Vec<usize>,
+}
+
+/// The pixel data type for an image HDU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageType {
+    UnsignedByte,
+    Short,
+    Long,
+    LongLong,
+    Float,
+    Double,
+}
+
+impl ImageType {
+    /// Convert to the FITS BITPIX value.
+    pub fn to_bitpix(self) -> i64 {
+        match self {
+            ImageType::UnsignedByte => 8,
+            ImageType::Short => 16,
+            ImageType::Long => 32,
+            ImageType::LongLong => 64,
+            ImageType::Float => -32,
+            ImageType::Double => -64,
+        }
+    }
+
+    /// Convert from FITS BITPIX value.
+    pub fn from_bitpix(bitpix: i64) -> Result<Self> {
+        match bitpix {
+            8 => Ok(ImageType::UnsignedByte),
+            16 => Ok(ImageType::Short),
+            32 => Ok(ImageType::Long),
+            64 => Ok(ImageType::LongLong),
+            -32 => Ok(ImageType::Float),
+            -64 => Ok(ImageType::Double),
+            _ => Err(Error::Message(format!("unsupported BITPIX: {bitpix}"))),
+        }
+    }
+}
+
+fn get_core_hdu(file: &FitsFile, hdu: &FitsHdu) -> Result<(fitsio_pure::hdu::FitsData, usize)> {
+    let fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+    if hdu.hdu_index >= fits_data.len() {
+        return Err(Error::Message(format!(
+            "HDU index {} out of range",
+            hdu.hdu_index
+        )));
+    }
+    Ok((fits_data, hdu.hdu_index))
+}
+
+/// Trait for types that can read image pixel data from a FITS file.
+pub trait ReadImage: Sized {
+    fn read_image(file: &FitsFile, hdu: &FitsHdu) -> Result<Vec<Self>>;
+    fn read_section(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        range: std::ops::Range<usize>,
+    ) -> Result<Vec<Self>>;
+    fn read_rows(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        start_row: usize,
+        num_rows: usize,
+    ) -> Result<Vec<Self>>;
+    fn read_region(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        ranges: &[std::ops::Range<usize>],
+    ) -> Result<Vec<Self>>;
+}
+
+/// Trait for types that can write image pixel data to a FITS file.
+pub trait WriteImage {
+    fn write_image(file: &mut FitsFile, hdu: &FitsHdu, data: &[Self]) -> Result<()>
+    where
+        Self: Sized;
+}
+
+fn extract_from_image_data<T: Clone>(
+    data: &fitsio_pure::image::ImageData,
+    convert_u8: fn(&[u8]) -> Vec<T>,
+    convert_i16: fn(&[i16]) -> Vec<T>,
+    convert_i32: fn(&[i32]) -> Vec<T>,
+    convert_i64: fn(&[i64]) -> Vec<T>,
+    convert_f32: fn(&[f32]) -> Vec<T>,
+    convert_f64: fn(&[f64]) -> Vec<T>,
+) -> Vec<T> {
+    match data {
+        fitsio_pure::image::ImageData::U8(v) => convert_u8(v),
+        fitsio_pure::image::ImageData::I16(v) => convert_i16(v),
+        fitsio_pure::image::ImageData::I32(v) => convert_i32(v),
+        fitsio_pure::image::ImageData::I64(v) => convert_i64(v),
+        fitsio_pure::image::ImageData::F32(v) => convert_f32(v),
+        fitsio_pure::image::ImageData::F64(v) => convert_f64(v),
+    }
+}
+
+fn ranges_to_tuples(ranges: &[std::ops::Range<usize>]) -> Vec<(usize, usize)> {
+    ranges.iter().map(|r| (r.start, r.end)).collect()
+}
+
+macro_rules! impl_read_image {
+    ($t:ty, $u8_fn:expr, $i16_fn:expr, $i32_fn:expr, $i64_fn:expr, $f32_fn:expr, $f64_fn:expr) => {
+        impl ReadImage for $t {
+            fn read_image(file: &FitsFile, hdu: &FitsHdu) -> Result<Vec<Self>> {
+                let (fits_data, idx) = get_core_hdu(file, hdu)?;
+                let core_hdu = &fits_data.hdus[idx];
+                let img = fitsio_pure::image::read_image_data(file.data(), core_hdu)?;
+                Ok(extract_from_image_data(
+                    &img, $u8_fn, $i16_fn, $i32_fn, $i64_fn, $f32_fn, $f64_fn,
+                ))
+            }
+
+            fn read_section(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                range: std::ops::Range<usize>,
+            ) -> Result<Vec<Self>> {
+                let (fits_data, idx) = get_core_hdu(file, hdu)?;
+                let core_hdu = &fits_data.hdus[idx];
+                let count = range.end.saturating_sub(range.start);
+                let img = fitsio_pure::image::read_image_section(
+                    file.data(),
+                    core_hdu,
+                    range.start,
+                    count,
+                )?;
+                Ok(extract_from_image_data(
+                    &img, $u8_fn, $i16_fn, $i32_fn, $i64_fn, $f32_fn, $f64_fn,
+                ))
+            }
+
+            fn read_rows(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                start_row: usize,
+                num_rows: usize,
+            ) -> Result<Vec<Self>> {
+                let (fits_data, idx) = get_core_hdu(file, hdu)?;
+                let core_hdu = &fits_data.hdus[idx];
+                let img = fitsio_pure::image::read_image_rows(
+                    file.data(),
+                    core_hdu,
+                    start_row,
+                    num_rows,
+                )?;
+                Ok(extract_from_image_data(
+                    &img, $u8_fn, $i16_fn, $i32_fn, $i64_fn, $f32_fn, $f64_fn,
+                ))
+            }
+
+            fn read_region(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                ranges: &[std::ops::Range<usize>],
+            ) -> Result<Vec<Self>> {
+                let (fits_data, idx) = get_core_hdu(file, hdu)?;
+                let core_hdu = &fits_data.hdus[idx];
+                let tuples = ranges_to_tuples(ranges);
+                let img = fitsio_pure::image::read_image_region(file.data(), core_hdu, &tuples)?;
+                Ok(extract_from_image_data(
+                    &img, $u8_fn, $i16_fn, $i32_fn, $i64_fn, $f32_fn, $f64_fn,
+                ))
+            }
+        }
+    };
+}
+
+impl_read_image!(
+    u8,
+    |v: &[u8]| v.to_vec(),
+    |v: &[i16]| v.iter().map(|&x| x as u8).collect(),
+    |v: &[i32]| v.iter().map(|&x| x as u8).collect(),
+    |v: &[i64]| v.iter().map(|&x| x as u8).collect(),
+    |v: &[f32]| v.iter().map(|&x| x as u8).collect(),
+    |v: &[f64]| v.iter().map(|&x| x as u8).collect()
+);
+
+impl_read_image!(
+    i16,
+    |v: &[u8]| v.iter().map(|&x| x as i16).collect(),
+    |v: &[i16]| v.to_vec(),
+    |v: &[i32]| v.iter().map(|&x| x as i16).collect(),
+    |v: &[i64]| v.iter().map(|&x| x as i16).collect(),
+    |v: &[f32]| v.iter().map(|&x| x as i16).collect(),
+    |v: &[f64]| v.iter().map(|&x| x as i16).collect()
+);
+
+impl_read_image!(
+    i32,
+    |v: &[u8]| v.iter().map(|&x| x as i32).collect(),
+    |v: &[i16]| v.iter().map(|&x| x as i32).collect(),
+    |v: &[i32]| v.to_vec(),
+    |v: &[i64]| v.iter().map(|&x| x as i32).collect(),
+    |v: &[f32]| v.iter().map(|&x| x as i32).collect(),
+    |v: &[f64]| v.iter().map(|&x| x as i32).collect()
+);
+
+impl_read_image!(
+    i64,
+    |v: &[u8]| v.iter().map(|&x| x as i64).collect(),
+    |v: &[i16]| v.iter().map(|&x| x as i64).collect(),
+    |v: &[i32]| v.iter().map(|&x| x as i64).collect(),
+    |v: &[i64]| v.to_vec(),
+    |v: &[f32]| v.iter().map(|&x| x as i64).collect(),
+    |v: &[f64]| v.iter().map(|&x| x as i64).collect()
+);
+
+impl_read_image!(
+    f32,
+    |v: &[u8]| v.iter().map(|&x| x as f32).collect(),
+    |v: &[i16]| v.iter().map(|&x| x as f32).collect(),
+    |v: &[i32]| v.iter().map(|&x| x as f32).collect(),
+    |v: &[i64]| v.iter().map(|&x| x as f32).collect(),
+    |v: &[f32]| v.to_vec(),
+    |v: &[f64]| v.iter().map(|&x| x as f32).collect()
+);
+
+impl_read_image!(
+    f64,
+    |v: &[u8]| v.iter().map(|&x| x as f64).collect(),
+    |v: &[i16]| v.iter().map(|&x| x as f64).collect(),
+    |v: &[i32]| v.iter().map(|&x| x as f64).collect(),
+    |v: &[i64]| v.iter().map(|&x| x as f64).collect(),
+    |v: &[f32]| v.iter().map(|&x| x as f64).collect(),
+    |v: &[f64]| v.to_vec()
+);
+
+macro_rules! impl_write_image {
+    ($t:ty, $bitpix:expr, $serialize_fn:path) => {
+        impl WriteImage for $t {
+            fn write_image(file: &mut FitsFile, hdu: &FitsHdu, data: &[Self]) -> Result<()> {
+                let fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+                let core_hdu = fits_data
+                    .hdus
+                    .get(hdu.hdu_index)
+                    .ok_or(Error::Message(format!(
+                        "HDU index {} out of range",
+                        hdu.hdu_index
+                    )))?;
+
+                let header_end = core_hdu.data_start;
+                let header_bytes = file.data()[..header_end].to_vec();
+                let serialized = $serialize_fn(data);
+
+                let mut new_data = Vec::with_capacity(header_bytes.len() + serialized.len());
+                new_data.extend_from_slice(&header_bytes);
+                new_data.extend_from_slice(&serialized);
+
+                // Append remaining HDUs after this one
+                let padded_data_len = fitsio_pure::block::padded_byte_len(core_hdu.data_len);
+                let next_hdu_start = core_hdu.data_start + padded_data_len;
+                if next_hdu_start < file.data().len() {
+                    new_data.extend_from_slice(&file.data()[next_hdu_start..]);
+                }
+
+                file.set_data(new_data);
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_write_image!(u8, 8, fitsio_pure::image::serialize_image_u8);
+impl_write_image!(i16, 16, fitsio_pure::image::serialize_image_i16);
+impl_write_image!(i32, 32, fitsio_pure::image::serialize_image_i32);
+impl_write_image!(i64, 64, fitsio_pure::image::serialize_image_i64);
+impl_write_image!(f32, -32, fitsio_pure::image::serialize_image_f32);
+impl_write_image!(f64, -64, fitsio_pure::image::serialize_image_f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fitsfile::FitsFile;
+
+    #[test]
+    fn image_type_bitpix_roundtrip() {
+        for &(it, bp) in &[
+            (ImageType::UnsignedByte, 8),
+            (ImageType::Short, 16),
+            (ImageType::Long, 32),
+            (ImageType::LongLong, 64),
+            (ImageType::Float, -32),
+            (ImageType::Double, -64),
+        ] {
+            assert_eq!(it.to_bitpix(), bp);
+            assert_eq!(ImageType::from_bitpix(bp).unwrap(), it);
+        }
+    }
+
+    #[test]
+    fn invalid_bitpix() {
+        assert!(ImageType::from_bitpix(7).is_err());
+    }
+
+    #[test]
+    fn create_and_read_image_f32() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![4],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<f32> = vec![1.0, 2.5, 3.125, 4.75];
+        f32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let read_back = f32::read_image(&f, &hdu).unwrap();
+        assert_eq!(read_back, pixels);
+    }
+
+    #[test]
+    fn create_and_read_image_f64() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Double,
+            dimensions: vec![3],
+        };
+        let hdu = f.create_image("DATA", &desc).unwrap();
+        let pixels: Vec<f64> = vec![1.5, -2.625, 0.0];
+        f64::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let read_back = f64::read_image(&f, &hdu).unwrap();
+        assert_eq!(read_back, pixels);
+    }
+
+    #[test]
+    fn create_and_read_image_u8() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::UnsignedByte,
+            dimensions: vec![4],
+        };
+        let hdu = f.create_image("RAW", &desc).unwrap();
+        let pixels: Vec<u8> = vec![0, 127, 200, 255];
+        u8::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let read_back = u8::read_image(&f, &hdu).unwrap();
+        assert_eq!(read_back, pixels);
+    }
+}

--- a/crates/fitsio-compat/src/lib.rs
+++ b/crates/fitsio-compat/src/lib.rs
@@ -1,5 +1,14 @@
 pub use fitsio_pure;
 
+pub mod errors;
+pub mod fitsfile;
+pub mod hdu;
+pub mod headers;
+pub mod images;
+pub mod tables;
+
+// FitsRow -- placeholder for future derive-macro based row reading (C6)
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/fitsio-compat/src/tables.rs
+++ b/crates/fitsio-compat/src/tables.rs
@@ -1,0 +1,329 @@
+use crate::errors::{Error, Result};
+use crate::fitsfile::FitsFile;
+use crate::hdu::FitsHdu;
+
+/// Describes one column in a table extension.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDescription {
+    pub name: String,
+    pub data_type: ColumnDataDescription,
+}
+
+/// Describes the data type and repeat count for a column.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDataDescription {
+    pub data_type: ColumnDataType,
+    pub repeat: usize,
+    pub width: usize,
+}
+
+/// The supported column data types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnDataType {
+    Int,
+    Long,
+    Float,
+    Double,
+    String,
+    Short,
+    Byte,
+    Logical,
+}
+
+/// A concrete column descriptor with computed byte width.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConcreteColumnDescription {
+    pub name: String,
+    pub data_type: ColumnDataType,
+    pub repeat: usize,
+    pub width: usize,
+}
+
+impl ColumnDescription {
+    /// Convert to a concrete descriptor.
+    pub fn to_concrete(&self) -> ConcreteColumnDescription {
+        ConcreteColumnDescription {
+            name: self.name.clone(),
+            data_type: self.data_type.data_type,
+            repeat: self.data_type.repeat,
+            width: self.data_type.width,
+        }
+    }
+}
+
+impl ColumnDataDescription {
+    /// Create a new column data description with the given type and repeat=1, width=1.
+    pub fn new(data_type: ColumnDataType) -> Self {
+        ColumnDataDescription {
+            data_type,
+            repeat: 1,
+            width: 1,
+        }
+    }
+
+    /// Set the repeat count.
+    pub fn with_repeat(mut self, repeat: usize) -> Self {
+        self.repeat = repeat;
+        self
+    }
+
+    /// Set the width (used for string columns).
+    pub fn with_width(mut self, width: usize) -> Self {
+        self.width = width;
+        self
+    }
+}
+
+/// A typed column read from a table.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Column {
+    Int32(Vec<i32>),
+    Int64(Vec<i64>),
+    Float(Vec<f32>),
+    Double(Vec<f64>),
+    String(Vec<std::string::String>),
+    Short(Vec<i16>),
+    Byte(Vec<u8>),
+    Logical(Vec<bool>),
+}
+
+fn get_core_hdu(file: &FitsFile, hdu: &FitsHdu) -> Result<(fitsio_pure::hdu::FitsData, usize)> {
+    let fits_data = fitsio_pure::hdu::parse_fits(file.data())?;
+    if hdu.hdu_index >= fits_data.len() {
+        return Err(Error::Message(format!(
+            "HDU index {} out of range",
+            hdu.hdu_index
+        )));
+    }
+    Ok((fits_data, hdu.hdu_index))
+}
+
+/// Trait for types that can be read from a table column.
+pub trait ReadsCol: Sized {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>>;
+}
+
+/// Trait for types that can be written to a table column.
+pub trait WritesCol: Sized {
+    fn write_col(file: &mut FitsFile, hdu: &FitsHdu, name: &str, data: &[Self]) -> Result<()>;
+}
+
+fn find_column_index(
+    cards: &[fitsio_pure::header::Card],
+    name: &str,
+    tfields: usize,
+) -> Result<usize> {
+    for i in 1..=tfields {
+        let ttype_key = format!("TTYPE{}", i);
+        for card in cards {
+            if card.keyword_str() == ttype_key {
+                if let Some(fitsio_pure::value::Value::String(ref s)) = card.value {
+                    if s.trim() == name {
+                        return Ok(i - 1);
+                    }
+                }
+            }
+        }
+    }
+    Err(Error::Message(format!("column '{}' not found", name)))
+}
+
+fn get_tfields(hdu: &fitsio_pure::hdu::Hdu) -> Result<usize> {
+    match &hdu.info {
+        fitsio_pure::hdu::HduInfo::BinaryTable { tfields, .. } => Ok(*tfields),
+        fitsio_pure::hdu::HduInfo::AsciiTable { tfields, .. } => Ok(*tfields),
+        _ => Err(Error::Message("HDU is not a table".to_string())),
+    }
+}
+
+impl ReadsCol for i32 {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
+        let (fits_data, idx) = get_core_hdu(file, hdu)?;
+        let core_hdu = &fits_data.hdus[idx];
+        let tfields = get_tfields(core_hdu)?;
+        let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
+        let col_data = fitsio_pure::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
+        match col_data {
+            fitsio_pure::bintable::BinaryColumnData::Int(v) => Ok(v),
+            fitsio_pure::bintable::BinaryColumnData::Short(v) => {
+                Ok(v.iter().map(|&x| x as i32).collect())
+            }
+            fitsio_pure::bintable::BinaryColumnData::Long(v) => {
+                Ok(v.iter().map(|&x| x as i32).collect())
+            }
+            _ => Err(Error::Message("column is not integer type".to_string())),
+        }
+    }
+}
+
+impl ReadsCol for i64 {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
+        let (fits_data, idx) = get_core_hdu(file, hdu)?;
+        let core_hdu = &fits_data.hdus[idx];
+        let tfields = get_tfields(core_hdu)?;
+        let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
+        let col_data = fitsio_pure::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
+        match col_data {
+            fitsio_pure::bintable::BinaryColumnData::Long(v) => Ok(v),
+            fitsio_pure::bintable::BinaryColumnData::Int(v) => {
+                Ok(v.iter().map(|&x| x as i64).collect())
+            }
+            fitsio_pure::bintable::BinaryColumnData::Short(v) => {
+                Ok(v.iter().map(|&x| x as i64).collect())
+            }
+            _ => Err(Error::Message("column is not integer type".to_string())),
+        }
+    }
+}
+
+impl ReadsCol for f32 {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
+        let (fits_data, idx) = get_core_hdu(file, hdu)?;
+        let core_hdu = &fits_data.hdus[idx];
+        let tfields = get_tfields(core_hdu)?;
+        let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
+        let col_data = fitsio_pure::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
+        match col_data {
+            fitsio_pure::bintable::BinaryColumnData::Float(v) => Ok(v),
+            fitsio_pure::bintable::BinaryColumnData::Double(v) => {
+                Ok(v.iter().map(|&x| x as f32).collect())
+            }
+            _ => Err(Error::Message("column is not float type".to_string())),
+        }
+    }
+}
+
+impl ReadsCol for f64 {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
+        let (fits_data, idx) = get_core_hdu(file, hdu)?;
+        let core_hdu = &fits_data.hdus[idx];
+        let tfields = get_tfields(core_hdu)?;
+        let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
+        let col_data = fitsio_pure::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
+        match col_data {
+            fitsio_pure::bintable::BinaryColumnData::Double(v) => Ok(v),
+            fitsio_pure::bintable::BinaryColumnData::Float(v) => {
+                Ok(v.iter().map(|&x| x as f64).collect())
+            }
+            fitsio_pure::bintable::BinaryColumnData::Int(v) => {
+                Ok(v.iter().map(|&x| x as f64).collect())
+            }
+            fitsio_pure::bintable::BinaryColumnData::Long(v) => {
+                Ok(v.iter().map(|&x| x as f64).collect())
+            }
+            _ => Err(Error::Message("column is not numeric type".to_string())),
+        }
+    }
+}
+
+impl ReadsCol for String {
+    fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
+        let (fits_data, idx) = get_core_hdu(file, hdu)?;
+        let core_hdu = &fits_data.hdus[idx];
+        let tfields = get_tfields(core_hdu)?;
+        let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
+        let col_data = fitsio_pure::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
+        match col_data {
+            fitsio_pure::bintable::BinaryColumnData::Ascii(v) => Ok(v),
+            _ => Err(Error::Message("column is not string type".to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fitsfile::FitsFile;
+
+    #[test]
+    fn column_description_to_concrete() {
+        let desc = ColumnDescription {
+            name: "X".to_string(),
+            data_type: ColumnDataDescription::new(ColumnDataType::Int),
+        };
+        let concrete = desc.to_concrete();
+        assert_eq!(concrete.name, "X");
+        assert_eq!(concrete.data_type, ColumnDataType::Int);
+        assert_eq!(concrete.repeat, 1);
+    }
+
+    #[test]
+    fn column_data_description_builder() {
+        let desc = ColumnDataDescription::new(ColumnDataType::String)
+            .with_repeat(20)
+            .with_width(20);
+        assert_eq!(desc.data_type, ColumnDataType::String);
+        assert_eq!(desc.repeat, 20);
+        assert_eq!(desc.width, 20);
+    }
+
+    #[test]
+    fn create_table_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("table.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let columns = vec![
+            fitsio_pure::bintable::BinaryColumnDescriptor {
+                name: Some("ID".to_string()),
+                repeat: 1,
+                col_type: fitsio_pure::bintable::BinaryColumnType::Int,
+                byte_width: 4,
+            },
+            fitsio_pure::bintable::BinaryColumnDescriptor {
+                name: Some("VAL".to_string()),
+                repeat: 1,
+                col_type: fitsio_pure::bintable::BinaryColumnType::Double,
+                byte_width: 8,
+            },
+        ];
+
+        let col_data = vec![
+            fitsio_pure::bintable::BinaryColumnData::Int(vec![10, 20, 30]),
+            fitsio_pure::bintable::BinaryColumnData::Double(vec![1.5, 2.5, 3.5]),
+        ];
+
+        let hdu_bytes =
+            fitsio_pure::bintable::serialize_binary_table_hdu(&columns, &col_data, 3).unwrap();
+
+        let mut data = f.data().to_vec();
+        data.extend_from_slice(&hdu_bytes);
+        f.set_data(data);
+
+        let hdu = f.hdu(1usize).unwrap();
+
+        let ids: Vec<i32> = i32::read_col(&f, &hdu, "ID").unwrap();
+        assert_eq!(ids, vec![10, 20, 30]);
+
+        let vals: Vec<f64> = f64::read_col(&f, &hdu, "VAL").unwrap();
+        assert!((vals[0] - 1.5).abs() < 1e-10);
+        assert!((vals[1] - 2.5).abs() < 1e-10);
+        assert!((vals[2] - 3.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn read_missing_column_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("table.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let columns = vec![fitsio_pure::bintable::BinaryColumnDescriptor {
+            name: Some("X".to_string()),
+            repeat: 1,
+            col_type: fitsio_pure::bintable::BinaryColumnType::Int,
+            byte_width: 4,
+        }];
+
+        let col_data = vec![fitsio_pure::bintable::BinaryColumnData::Int(vec![1])];
+
+        let hdu_bytes =
+            fitsio_pure::bintable::serialize_binary_table_hdu(&columns, &col_data, 1).unwrap();
+
+        let mut data = f.data().to_vec();
+        data.extend_from_slice(&hdu_bytes);
+        f.set_data(data);
+
+        let hdu = f.hdu(1usize).unwrap();
+        assert!(i32::read_col(&f, &hdu, "MISSING").is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Implements compatibility crate mirroring the `fitsio` crate's API surface
- Adds `FitsFile`, `FitsHdu`, `HduInfo`, `ImageType`, column types, and key read/write traits
- Includes `errors.rs`, `headers.rs`, `images.rs`, `hdu.rs`, `fitsfile.rs`, `tables.rs` modules
- 36 compat tests passing, 431 total workspace tests passing

## Test plan
- [x] `cargo test --workspace` — 431 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean