### PR TITLE
Bump all crate versions to 0.9.0

### DIFF
--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "fitsio-pure"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
+description = "Pure Rust FITS file reader and writer"
+repository = "https://github.com/OrbitalCommons/fitsio-pure"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Summary
- Update fitsio-pure, fitsio-compat, and fitsio-tools from 0.1.0 to 0.9.0
- Add version constraints to path dependencies for crates.io compatibility

## Test plan
- [x] cargo check --workspace passes
- [ ] Publish to crates.io in dependency order after merge