### PR TITLE
Add ndarray support via array feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --workspace
+      - run: cargo test --features array
 
   clippy:
     runs-on: ubuntu-latest
@@ -24,6 +25,7 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --all-targets --features array -- -D warnings
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +52,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "fitsio-pure"
 version = "0.1.0"
 dependencies = [
+ "ndarray",
  "tempfile",
 ]
 
@@ -138,16 +145,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "prettyplease"
@@ -182,6 +256,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rustix"

--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -9,6 +9,7 @@ default = ["std"]
 std = []
 compat = ["std"]
 cli = ["std"]
+array = ["dep:ndarray", "compat"]
 
 [dev-dependencies]
 tempfile = "3.25"
@@ -22,3 +23,6 @@ required-features = ["cli"]
 name = "fitsconv"
 path = "src/bin/fitsconv.rs"
 required-features = ["cli"]
+
+[dependencies]
+ndarray = { version = "0.17.2", optional = true }

--- a/crates/fitsio-pure/src/compat/mod.rs
+++ b/crates/fitsio-pure/src/compat/mod.rs
@@ -3,6 +3,8 @@ pub mod fitsfile;
 pub mod hdu;
 pub mod headers;
 pub mod images;
+#[cfg(feature = "array")]
+pub mod ndarray_compat;
 pub mod tables;
 
 #[cfg(test)]

--- a/crates/fitsio-pure/src/compat/ndarray_compat.rs
+++ b/crates/fitsio-pure/src/compat/ndarray_compat.rs
@@ -1,0 +1,238 @@
+use ndarray::{Array, ArrayD};
+
+use super::errors::Result;
+use super::fitsfile::FitsFile;
+use super::hdu::{FitsHdu, HduInfo};
+use super::images::ReadImage;
+
+impl<T> ReadImage for ArrayD<T>
+where
+    T: Clone + ReadImage,
+{
+    fn read_image(file: &FitsFile, hdu: &FitsHdu) -> Result<Vec<Self>> {
+        let data: Vec<T> = T::read_image(file, hdu)?;
+        let shape = image_shape(file, hdu)?;
+        let arr = Array::from_shape_vec(shape, data)
+            .map_err(|e| super::errors::Error::Message(e.to_string()))?;
+        Ok(vec![arr])
+    }
+
+    fn read_section(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        range: std::ops::Range<usize>,
+    ) -> Result<Vec<Self>> {
+        let data: Vec<T> = T::read_section(file, hdu, range)?;
+        let shape = vec![data.len()];
+        let arr = Array::from_shape_vec(shape, data)
+            .map_err(|e| super::errors::Error::Message(e.to_string()))?;
+        Ok(vec![arr])
+    }
+
+    fn read_rows(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        start_row: usize,
+        num_rows: usize,
+    ) -> Result<Vec<Self>> {
+        let data: Vec<T> = T::read_rows(file, hdu, start_row, num_rows)?;
+        let full_shape = image_shape(file, hdu)?;
+        // A "row" in FITS is one slice along NAXIS1 (the first/fastest axis).
+        // read_image_rows returns num_rows * naxes[0] elements.
+        let row_length = if !full_shape.is_empty() {
+            full_shape[0]
+        } else {
+            data.len() / num_rows
+        };
+        let shape = if num_rows == 1 {
+            vec![row_length]
+        } else {
+            vec![num_rows, row_length]
+        };
+        let arr = Array::from_shape_vec(shape, data)
+            .map_err(|e| super::errors::Error::Message(e.to_string()))?;
+        Ok(vec![arr])
+    }
+
+    fn read_region(
+        file: &FitsFile,
+        hdu: &FitsHdu,
+        ranges: &[std::ops::Range<usize>],
+    ) -> Result<Vec<Self>> {
+        let data: Vec<T> = T::read_region(file, hdu, ranges)?;
+        let shape: Vec<usize> = ranges.iter().map(|r| r.end - r.start).collect();
+        let arr = Array::from_shape_vec(shape, data)
+            .map_err(|e| super::errors::Error::Message(e.to_string()))?;
+        Ok(vec![arr])
+    }
+}
+
+fn image_shape(file: &FitsFile, hdu: &FitsHdu) -> Result<Vec<usize>> {
+    match hdu.info(file)? {
+        HduInfo::ImageInfo { shape, .. } => Ok(shape),
+        _ => Err(super::errors::Error::Message(
+            "HDU is not an image".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compat::images::{ImageDescription, ImageType, WriteImage};
+
+    #[test]
+    fn read_image_2d_f32() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![3, 4],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        f32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let result: Vec<ArrayD<f32>> = ArrayD::<f32>::read_image(&f, &hdu).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[3, 4]);
+        assert_eq!(arr[[0, 0]], 0.0);
+        assert_eq!(arr[[2, 3]], 11.0);
+    }
+
+    #[test]
+    fn read_image_3d_f64() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img3d.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Double,
+            dimensions: vec![2, 3, 4],
+        };
+        let hdu = f.create_image("CUBE", &desc).unwrap();
+        let pixels: Vec<f64> = (0..24).map(|i| i as f64).collect();
+        f64::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let result: Vec<ArrayD<f64>> = ArrayD::<f64>::read_image(&f, &hdu).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[2, 3, 4]);
+        assert_eq!(arr[[0, 0, 0]], 0.0);
+        assert_eq!(arr[[1, 2, 3]], 23.0);
+    }
+
+    #[test]
+    fn read_section_returns_1d() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sec.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![3, 4],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        f32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let result: Vec<ArrayD<f32>> = ArrayD::<f32>::read_section(&f, &hdu, 4..8).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[4]);
+        assert_eq!(arr[0], 4.0);
+        assert_eq!(arr[3], 7.0);
+    }
+
+    #[test]
+    fn read_rows_2d() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rows.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        // dimensions [5, 4] means NAXIS1=5 (columns), NAXIS2=4 (rows)
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![5, 4],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        f32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        // Reading 2 rows starting at row 1 gives 2*5=10 elements
+        let result: Vec<ArrayD<f32>> = ArrayD::<f32>::read_rows(&f, &hdu, 1, 2).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[2, 5]);
+        assert_eq!(arr[[0, 0]], 5.0); // row 1, col 0
+        assert_eq!(arr[[1, 4]], 14.0); // row 2, col 4
+    }
+
+    #[test]
+    fn read_region_2d() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("region.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Float,
+            dimensions: vec![5, 4],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<f32> = (0..20).map(|i| i as f32).collect();
+        f32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let result: Vec<ArrayD<f32>> = ArrayD::<f32>::read_region(&f, &hdu, &[1..3, 0..2]).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[2, 2]);
+    }
+
+    #[test]
+    fn read_image_1d() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img1d.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Long,
+            dimensions: vec![6],
+        };
+        let hdu = f.create_image("DATA", &desc).unwrap();
+        let pixels: Vec<i32> = vec![10, 20, 30, 40, 50, 60];
+        i32::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let result: Vec<ArrayD<i32>> = ArrayD::<i32>::read_image(&f, &hdu).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[6]);
+        assert_eq!(arr[0], 10);
+        assert_eq!(arr[5], 60);
+    }
+
+    #[test]
+    fn read_image_type_conversion() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("conv.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type: ImageType::Short,
+            dimensions: vec![2, 3],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        let pixels: Vec<i16> = vec![1, 2, 3, 4, 5, 6];
+        i16::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        // Read i16 data as f32 array
+        let result: Vec<ArrayD<f32>> = ArrayD::<f32>::read_image(&f, &hdu).unwrap();
+        assert_eq!(result.len(), 1);
+        let arr = &result[0];
+        assert_eq!(arr.shape(), &[2, 3]);
+        assert_eq!(arr[[0, 0]], 1.0);
+        assert_eq!(arr[[1, 2]], 6.0);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional `ndarray` dependency (v0.17.2) behind an `array` feature flag
- Implements `ReadImage` for `ArrayD<T>` so images can be read directly as multi-dimensional ndarray arrays
- Supports all existing pixel types (u8, i16, i32, i64, f32, f64) with automatic type conversion
- All four read methods work: `read_image`, `read_section`, `read_rows`, `read_region`
- Adds `array` feature to CI test and clippy steps

This unblocks 6 potential adopters that depend on fitsio's `array` feature: f2i, fitsrotate_rs, eventide, twinkle, MARVELpipeline, and ccdi.

## Usage
```toml
[dependencies]
fitsio-pure = { version = "0.1", features = ["array"] }
```

```rust
use ndarray::ArrayD;
use fitsio_pure::compat::{fitsfile::FitsFile, images::ReadImage};

let f = FitsFile::open("image.fits")?;
let hdu = f.primary_hdu()?;
let data: Vec<ArrayD<f32>> = ArrayD::<f32>::read_image(&f, &hdu)?;
let arr = &data[0]; // shape matches FITS dimensions
```

## Test plan
- [x] 7 new tests covering 1D/2D/3D images, sections, rows, regions, type conversion
- [x] All 438 existing tests still pass
- [x] `cargo clippy --features array` clean
- [x] `cargo fmt` clean
- [x] wasm32 no_std build unaffected
- [x] CLI build unaffected