### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-pure"
-version = "0.9.0"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Pure Rust FITS file reader and writer"


### PR DESCRIPTION
## Summary
- Bump crate version from 0.9.0 to 0.9.2 for crates.io publish