### PR TITLE
Optimize read path with bytemuck and HDU caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +76,7 @@ dependencies = [
 name = "fitsio-pure"
 version = "0.9.2"
 dependencies = [
+ "bytemuck",
  "ndarray",
  "tempfile",
 ]

--- a/README.md
+++ b/README.md
@@ -177,14 +177,14 @@ Run with `cargo run -p fits-benchmark --features pure,cfitsio --no-default-featu
 
 | Test | fitsio-pure Write MP/s | cfitsio Write MP/s | fitsio-pure Read MP/s | cfitsio Read MP/s |
 |------|----------------------:|-------------------:|---------------------:|------------------:|
-| f32 1024x1024 | 90 | 290 | 100 | 981 |
-| f64 1024x1024 | 42 | 147 | 47 | 378 |
-| i32 1024x1024 | 187 | 288 | 295 | 1025 |
-| f32 4096x4096 | 98 | 278 | 96 | 315 |
-| f64 4096x4096 | 51 | 147 | 49 | 161 |
-| i32 4096x4096 | 103 | 283 | 96 | 311 |
+| f32 1024x1024 | 88 | 290 | 323 | 981 |
+| f64 1024x1024 | 40 | 147 | 138 | 378 |
+| i32 1024x1024 | 179 | 288 | 349 | 1025 |
+| f32 4096x4096 | 78 | 278 | 103 | 315 |
+| f64 4096x4096 | 49 | 147 | 63 | 161 |
+| i32 4096x4096 | 99 | 283 | 128 | 311 |
 
-cfitsio is faster because it maintains open file handles and writes data in-place, while fitsio-pure's compat layer re-parses headers and rebuilds the byte buffer on each operation. The core serialization (big-endian byte swaps) is similar speed -- the gap is architectural overhead in the compat layer that can be optimized in future releases.
+cfitsio is faster because it maintains open file handles and writes data in-place, while fitsio-pure rebuilds the byte buffer on writes. Read performance is much closer thanks to HDU metadata caching and bulk endian conversion via bytemuck.
 
 Full results and analysis in [`crates/fits-benchmark/README.md`](crates/fits-benchmark/README.md).
 

--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -27,4 +27,5 @@ path = "src/bin/fitsconv.rs"
 required-features = ["cli"]
 
 [dependencies]
+bytemuck = { version = "1.25.0", features = ["extern_crate_alloc"] }
 ndarray = { version = "0.17.2", optional = true }

--- a/crates/fitsio-pure/src/compat/hdu.rs
+++ b/crates/fitsio-pure/src/compat/hdu.rs
@@ -43,7 +43,7 @@ impl FitsHdu {
 
     /// Return information about the type and shape of data in this HDU.
     pub fn info(&self, file: &FitsFile) -> Result<HduInfo> {
-        let fits_data = crate::hdu::parse_fits(file.data())?;
+        let fits_data = file.parsed()?;
         let hdu = fits_data.get(self.hdu_index).ok_or(Error::Message(format!(
             "HDU index {} out of range",
             self.hdu_index

--- a/crates/fitsio-pure/src/compat/headers.rs
+++ b/crates/fitsio-pure/src/compat/headers.rs
@@ -20,7 +20,7 @@ pub trait WritesKey {
 }
 
 fn find_card_value(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<crate::value::Value> {
-    let fits_data = crate::hdu::parse_fits(file.data())?;
+    let fits_data = file.parsed()?;
     let core_hdu = fits_data.get(hdu.hdu_index).ok_or(Error::Message(format!(
         "HDU index {} not found",
         hdu.hdu_index

--- a/crates/fitsio-pure/src/compat/tables.rs
+++ b/crates/fitsio-pure/src/compat/tables.rs
@@ -87,15 +87,15 @@ pub enum Column {
     Logical(Vec<bool>),
 }
 
-fn get_core_hdu(file: &FitsFile, hdu: &FitsHdu) -> Result<(crate::hdu::FitsData, usize)> {
-    let fits_data = crate::hdu::parse_fits(file.data())?;
+fn validate_hdu_index(file: &FitsFile, hdu: &FitsHdu) -> Result<usize> {
+    let fits_data = file.parsed()?;
     if hdu.hdu_index >= fits_data.len() {
         return Err(Error::Message(format!(
             "HDU index {} out of range",
             hdu.hdu_index
         )));
     }
-    Ok((fits_data, hdu.hdu_index))
+    Ok(hdu.hdu_index)
 }
 
 /// Trait for types that can be read from a table column.
@@ -134,8 +134,9 @@ fn get_tfields(hdu: &crate::hdu::Hdu) -> Result<usize> {
 
 impl ReadsCol for i32 {
     fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
-        let (fits_data, idx) = get_core_hdu(file, hdu)?;
-        let core_hdu = &fits_data.hdus[idx];
+        let idx = validate_hdu_index(file, hdu)?;
+        let parsed = file.parsed()?;
+        let core_hdu = &parsed.hdus[idx];
         let tfields = get_tfields(core_hdu)?;
         let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
         let col_data = crate::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
@@ -152,8 +153,9 @@ impl ReadsCol for i32 {
 
 impl ReadsCol for i64 {
     fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
-        let (fits_data, idx) = get_core_hdu(file, hdu)?;
-        let core_hdu = &fits_data.hdus[idx];
+        let idx = validate_hdu_index(file, hdu)?;
+        let parsed = file.parsed()?;
+        let core_hdu = &parsed.hdus[idx];
         let tfields = get_tfields(core_hdu)?;
         let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
         let col_data = crate::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
@@ -170,8 +172,9 @@ impl ReadsCol for i64 {
 
 impl ReadsCol for f32 {
     fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
-        let (fits_data, idx) = get_core_hdu(file, hdu)?;
-        let core_hdu = &fits_data.hdus[idx];
+        let idx = validate_hdu_index(file, hdu)?;
+        let parsed = file.parsed()?;
+        let core_hdu = &parsed.hdus[idx];
         let tfields = get_tfields(core_hdu)?;
         let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
         let col_data = crate::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
@@ -187,8 +190,9 @@ impl ReadsCol for f32 {
 
 impl ReadsCol for f64 {
     fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
-        let (fits_data, idx) = get_core_hdu(file, hdu)?;
-        let core_hdu = &fits_data.hdus[idx];
+        let idx = validate_hdu_index(file, hdu)?;
+        let parsed = file.parsed()?;
+        let core_hdu = &parsed.hdus[idx];
         let tfields = get_tfields(core_hdu)?;
         let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
         let col_data = crate::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;
@@ -206,8 +210,9 @@ impl ReadsCol for f64 {
 
 impl ReadsCol for String {
     fn read_col(file: &FitsFile, hdu: &FitsHdu, name: &str) -> Result<Vec<Self>> {
-        let (fits_data, idx) = get_core_hdu(file, hdu)?;
-        let core_hdu = &fits_data.hdus[idx];
+        let idx = validate_hdu_index(file, hdu)?;
+        let parsed = file.parsed()?;
+        let core_hdu = &parsed.hdus[idx];
         let tfields = get_tfields(core_hdu)?;
         let col_idx = find_column_index(&core_hdu.cards, name, tfields)?;
         let col_data = crate::bintable::read_binary_column(file.data(), core_hdu, col_idx)?;


### PR DESCRIPTION
## Summary
- Add **bytemuck** for safe bulk endian conversion (`pod_collect_to_vec` + in-place byte swaps) replacing element-by-element loops
- **Cache parsed HDU metadata** in `FitsFile` via `RefCell<Option<FitsData>>`, avoiding re-parsing on repeated reads
- Use cached parse across all compat modules (images, tables, headers, hdu)
- Update benchmark numbers in README and benchmark crate

## Performance impact (read throughput)

| Test | Before MP/s | After MP/s | Speedup |
|------|------------|-----------|---------|
| f32 256x256 | 151 | 720 | **4.8x** |
| i32 1024x1024 | 295 | 349 | 1.2x |
| f32 1024x1024 | 100 | 323 | **3.2x** |
| f64 1024x1024 | 47 | 138 | **2.9x** |
| f32 4096x4096 | 96 | 103 | 1.1x |
| i32 4096x4096 | 96 | 128 | 1.3x |

Small images see the biggest gain (parsing overhead was dominant). Large images see modest gains from reduced allocations.

## Test plan
- [x] `cargo test --workspace` (434 tests pass)
- [x] `cargo test --features compat`
- [x] `cargo clippy --all-targets --features compat -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --target wasm32-unknown-unknown --no-default-features`
- [x] `cargo build --features cli`