### PR TITLE
Add FitsHdu::read_col for fitsio compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "fitsio-pure"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "bytemuck",
  "ndarray",

--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "fitsio-pure"
-version = "0.9.2"
+version = "0.9.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Pure Rust FITS file reader and writer"
+readme = "../../README.md"
 repository = "https://github.com/OrbitalCommons/fitsio-pure"
 
 [features]

--- a/crates/fitsio-pure/src/compat/hdu.rs
+++ b/crates/fitsio-pure/src/compat/hdu.rs
@@ -1,6 +1,7 @@
 use super::errors::{Error, Result};
 use super::fitsfile::FitsFile;
 use super::headers::{ReadsKey, WritesKey};
+use super::tables::ReadsCol;
 
 /// Lightweight handle to one HDU within a FITS file.
 ///
@@ -39,6 +40,11 @@ impl FitsHdu {
         value: &T,
     ) -> Result<()> {
         T::write_key(file, self, name, value)
+    }
+
+    /// Read a column from a binary table HDU.
+    pub fn read_col<T: ReadsCol>(&self, file: &FitsFile, name: &str) -> Result<Vec<T>> {
+        T::read_col(file, self, name)
     }
 
     /// Return information about the type and shape of data in this HDU.


### PR DESCRIPTION
## Summary
- Adds `FitsHdu::read_col()` convenience method matching the `fitsio` crate's API
- Adds `readme` field to Cargo.toml for crates.io display
- Bumps version to 0.9.4

Motivated by https://github.com/TrystanScottLambert/dog/issues/21 — preparing a PR to switch `dog` from cfitsio to fitsio-pure.

## Test plan
- [x] `cargo test --features compat` passes
- [x] `cargo clippy --all-targets --features compat -- -D warnings` clean