### PR TITLE
Add doc comments and enable missing_docs lint

### DIFF
--- a/crates/fitsio-pure/src/bintable.rs
+++ b/crates/fitsio-pure/src/bintable.rs
@@ -68,23 +68,39 @@ pub struct BinaryColumnDescriptor {
 /// Column data extracted from a binary table.
 #[derive(Debug, Clone, PartialEq)]
 pub enum BinaryColumnData {
+    /// Logical (L) column.
     Logical(Vec<bool>),
+    /// Unsigned byte (B) column.
     Byte(Vec<u8>),
+    /// 16-bit integer (I) column.
     Short(Vec<i16>),
+    /// 32-bit integer (J) column.
     Int(Vec<i32>),
+    /// 64-bit integer (K) column.
     Long(Vec<i64>),
+    /// 32-bit float (E) column.
     Float(Vec<f32>),
+    /// 64-bit float (D) column.
     Double(Vec<f64>),
+    /// Complex float (C) column.
     ComplexFloat(Vec<(f32, f32)>),
+    /// Complex double (M) column.
     ComplexDouble(Vec<(f64, f64)>),
+    /// ASCII string (A) column.
     Ascii(Vec<String>),
+    /// Bit array (X) column, one byte-vec per row.
     Bit(Vec<Vec<u8>>),
-    /// Variable-length array column: one inner Vec per row.
+    /// Variable-length byte array column: one inner Vec per row.
     VarByte(Vec<Vec<u8>>),
+    /// Variable-length i16 array column.
     VarShort(Vec<Vec<i16>>),
+    /// Variable-length i32 array column.
     VarInt(Vec<Vec<i32>>),
+    /// Variable-length i64 array column.
     VarLong(Vec<Vec<i64>>),
+    /// Variable-length f32 array column.
     VarFloat(Vec<Vec<f32>>),
+    /// Variable-length f64 array column.
     VarDouble(Vec<Vec<f64>>),
 }
 

--- a/crates/fitsio-pure/src/compat/mod.rs
+++ b/crates/fitsio-pure/src/compat/mod.rs
@@ -1,10 +1,20 @@
+//! Compatibility layer mirroring the [`fitsio`](https://crates.io/crates/fitsio) crate API.
+#![allow(missing_docs)]
+
+/// Error types for the compat layer.
 pub mod errors;
+/// FITS file open/create/save operations.
 pub mod fitsfile;
+/// HDU handle and metadata queries.
 pub mod hdu;
+/// Header keyword read/write traits.
 pub mod headers;
+/// Image pixel read/write traits and types.
 pub mod images;
+/// ndarray integration (requires the `array` feature).
 #[cfg(feature = "array")]
 pub mod ndarray_compat;
+/// Table column read/write traits and types.
 pub mod tables;
 
 #[cfg(test)]

--- a/crates/fitsio-pure/src/extension.rs
+++ b/crates/fitsio-pure/src/extension.rs
@@ -11,8 +11,11 @@ use crate::value::Value;
 /// The type of FITS extension, determined by the XTENSION keyword value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtensionType {
+    /// XTENSION = 'IMAGE'.
     Image,
+    /// XTENSION = 'TABLE'.
     AsciiTable,
+    /// XTENSION = 'BINTABLE'.
     BinaryTable,
 }
 
@@ -37,12 +40,19 @@ impl ExtensionType {
 /// A parsed FITS extension header with all mandatory keyword values extracted.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExtensionHeader {
+    /// The extension type (IMAGE, TABLE, or BINTABLE).
     pub xtension: ExtensionType,
+    /// Bits per pixel / data value.
     pub bitpix: i64,
+    /// Number of axes.
     pub naxis: usize,
+    /// Axis dimensions (NAXIS1, NAXIS2, ...).
     pub naxes: Vec<usize>,
+    /// Parameter count (heap size for binary tables).
     pub pcount: usize,
+    /// Group count (always 1 for standard extensions).
     pub gcount: usize,
+    /// All header cards from this extension.
     pub cards: Vec<Card>,
 }
 

--- a/crates/fitsio-pure/src/header.rs
+++ b/crates/fitsio-pure/src/header.rs
@@ -56,9 +56,13 @@ impl Card {
 /// The type of HDU, which determines required keywords per the FITS standard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HduType {
+    /// Primary HDU (starts with SIMPLE=T).
     Primary,
+    /// Image extension.
     Image,
+    /// ASCII table extension.
     AsciiTable,
+    /// Binary table extension.
     BinaryTable,
 }
 

--- a/crates/fitsio-pure/src/image.rs
+++ b/crates/fitsio-pure/src/image.rs
@@ -22,11 +22,17 @@ use crate::value::Value;
 /// Image pixel data extracted from a FITS HDU, typed by BITPIX.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ImageData {
+    /// BITPIX = 8: unsigned 8-bit integers.
     U8(Vec<u8>),
+    /// BITPIX = 16: signed 16-bit integers.
     I16(Vec<i16>),
+    /// BITPIX = 32: signed 32-bit integers.
     I32(Vec<i32>),
+    /// BITPIX = 64: signed 64-bit integers.
     I64(Vec<i64>),
+    /// BITPIX = -32: IEEE 754 single-precision floats.
     F32(Vec<f32>),
+    /// BITPIX = -64: IEEE 754 double-precision floats.
     F64(Vec<f64>),
 }
 

--- a/crates/fitsio-pure/src/lib.rs
+++ b/crates/fitsio-pure/src/lib.rs
@@ -1,24 +1,49 @@
+//! Pure Rust FITS file reader/writer.
+//!
+//! Parse FITS files with [`hdu::parse_fits`], then read image pixels via
+//! [`image::read_image_data`] or table columns via [`bintable`] and [`table`].
+//! Tile-compressed images (RICE_1 / GZIP_1) are handled transparently through
+//! the [`tiled`] module.
+//!
+//! The core library is `no_std`-compatible (requires `alloc`). Enable the
+//! `compat` feature for a drop-in replacement of the `fitsio` crate API.
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
 
 extern crate alloc;
 
+/// Binary table (BINTABLE) column parsing and data extraction.
 pub mod bintable;
+/// FITS 2880-byte block utilities and constants.
 pub mod block;
+/// HDU checksum computation and encoding (CHECKSUM/DATASUM).
 pub mod checksum;
+/// Big-endian byte conversion helpers for FITS data types.
 pub mod endian;
+/// Error types used throughout the crate.
 pub mod error;
+/// Extension HDU (IMAGE/TABLE/BINTABLE) header parsing.
 pub mod extension;
+/// Top-level FITS parsing: HDU discovery and metadata extraction.
 pub mod hdu;
+/// Header card parsing and serialization.
 pub mod header;
+/// Image pixel data reading and type conversion.
 pub mod image;
+/// Minimal `Read`/`Write`/`Seek` traits for `no_std` environments.
 pub mod io;
+/// Primary HDU header parsing and construction.
 pub mod primary;
+/// ASCII table (TABLE) column parsing and data extraction.
 pub mod table;
+/// Tile-compressed image decompression (RICE_1, GZIP_1).
 pub mod tiled;
+/// FITS header value representation (integer, float, string, logical).
 pub mod value;
 
 pub use block::{BLOCK_SIZE, CARDS_PER_BLOCK, CARD_SIZE};
 pub use error::{Error, Result};
 
+/// Compatibility layer mirroring the `fitsio` crate API.
 #[cfg(feature = "compat")]
 pub mod compat;


### PR DESCRIPTION
## Summary
- Add `#![warn(missing_docs)]` to catch undocumented public items at compile time
- Add crate-level documentation to `lib.rs` with module descriptions
- Document all `HduInfo` variants and fields, `FitsData` methods, `Hdu` fields
- Document `ImageData`, `BinaryColumnData`, `ExtensionType`, `ExtensionHeader`, and `HduType` variants/fields
- Suppress `missing_docs` for compat module (mirrors external API)

## Test plan
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets --features compat -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --target wasm32-unknown-unknown --no-default-features` succeeds
- [x] `cargo build --features cli` succeeds
- [x] Zero `missing_docs` warnings