### PR TITLE
Add native unsigned image support (u16/u32/u64) (#64.1)

### DIFF
--- a/crates/fitsio-pure/src/compat/fitsfile.rs
+++ b/crates/fitsio-pure/src/compat/fitsfile.rs
@@ -164,6 +164,21 @@ impl FitsFile {
             1,
         )?;
 
+        // For unsigned pixel types, record the cfitsio storage convention
+        // (signed BITPIX offset by BZERO) so readers recover unsigned values.
+        if let Some(bzero) = desc.data_type.unsigned_bzero() {
+            cards.push(crate::header::Card {
+                keyword: make_keyword("BZERO"),
+                value: Some(bzero),
+                comment: None,
+            });
+            cards.push(crate::header::Card {
+                keyword: make_keyword("BSCALE"),
+                value: Some(crate::value::Value::Integer(1)),
+                comment: None,
+            });
+        }
+
         let extname_card = crate::header::Card {
             keyword: make_keyword("EXTNAME"),
             value: Some(crate::value::Value::String(extname.to_string())),

--- a/crates/fitsio-pure/src/compat/images.rs
+++ b/crates/fitsio-pure/src/compat/images.rs
@@ -14,22 +14,46 @@ pub struct ImageDescription {
 pub enum ImageType {
     UnsignedByte,
     Short,
+    /// Unsigned 16-bit (`u16`): stored as `BITPIX = 16` with `BZERO = 32768`.
+    UnsignedShort,
     Long,
+    /// Unsigned 32-bit (`u32`): stored as `BITPIX = 32` with `BZERO = 2^31`.
+    UnsignedLong,
     LongLong,
+    /// Unsigned 64-bit (`u64`): stored as `BITPIX = 64` with `BZERO = 2^63`.
+    UnsignedLongLong,
     Float,
     Double,
 }
 
 impl ImageType {
     /// Convert to the FITS BITPIX value.
+    ///
+    /// Unsigned types map to their signed storage BITPIX; the unsigned
+    /// interpretation is carried by the `BZERO` keyword (cfitsio convention).
     pub fn to_bitpix(self) -> i64 {
         match self {
             ImageType::UnsignedByte => 8,
-            ImageType::Short => 16,
-            ImageType::Long => 32,
-            ImageType::LongLong => 64,
+            ImageType::Short | ImageType::UnsignedShort => 16,
+            ImageType::Long | ImageType::UnsignedLong => 32,
+            ImageType::LongLong | ImageType::UnsignedLongLong => 64,
             ImageType::Float => -32,
             ImageType::Double => -64,
+        }
+    }
+
+    /// The `BZERO` offset for the cfitsio unsigned-integer storage convention,
+    /// or `None` for signed/floating types.
+    ///
+    /// `u16`/`u32` use an integer `BZERO`; `u64` uses `2^63`, which exceeds
+    /// `i64::MAX`, so it is stored as a (exactly representable) float.
+    pub(crate) fn unsigned_bzero(self) -> Option<crate::value::Value> {
+        use crate::value::Value;
+        match self {
+            ImageType::UnsignedShort => Some(Value::Integer(32_768)),
+            ImageType::UnsignedLong => Some(Value::Integer(2_147_483_648)),
+            ImageType::UnsignedLongLong => Some(Value::Float(9_223_372_036_854_775_808.0)),
+            _ => None,
         }
     }
 
@@ -133,6 +157,87 @@ fn extract_from_image_data<T: Clone>(
 fn ranges_to_tuples(ranges: &[std::ops::Range<usize>]) -> Vec<(usize, usize)> {
     ranges.iter().map(|r| (r.start, r.end)).collect()
 }
+
+/// Collect raw stored pixel values as `i64`, regardless of the on-disk type.
+fn image_data_to_i64(data: &crate::image::ImageData) -> Vec<i64> {
+    extract_from_image_data(
+        data,
+        |v: &[u8]| v.iter().map(|&x| x as i64).collect(),
+        |v: &[i16]| v.iter().map(|&x| x as i64).collect(),
+        |v: &[i32]| v.iter().map(|&x| x as i64).collect(),
+        |v: &[i64]| v.to_vec(),
+        |v: &[f32]| v.iter().map(|&x| x as i64).collect(),
+        |v: &[f64]| v.iter().map(|&x| x as i64).collect(),
+    )
+}
+
+/// Read raw stored pixels (via `read`) as `i64` together with the HDU's `BZERO`
+/// offset, for recovering values written with the unsigned storage convention.
+fn read_raw_with_bzero<F>(file: &FitsFile, hdu: &FitsHdu, read: F) -> Result<(Vec<i64>, i128)>
+where
+    F: FnOnce(&[u8], &crate::hdu::Hdu) -> crate::error::Result<crate::image::ImageData>,
+{
+    let idx = validate_hdu_index(file, hdu)?;
+    let parsed = file.parsed()?;
+    let core_hdu = &parsed.hdus[idx];
+    let (_bscale, bzero) = crate::image::extract_bscale_bzero(&core_hdu.cards);
+    let img = read(file.data(), core_hdu)?;
+    Ok((image_data_to_i64(&img), bzero as i128))
+}
+
+/// Implement `ReadImage` for an unsigned type, recovering each value as
+/// `stored + BZERO` (cfitsio unsigned storage convention).
+macro_rules! impl_read_image_unsigned {
+    ($t:ty) => {
+        impl ReadImage for $t {
+            fn read_image(file: &FitsFile, hdu: &FitsHdu) -> Result<Vec<Self>> {
+                let (raw, bz) =
+                    read_raw_with_bzero(file, hdu, |d, h| crate::image::read_image_data(d, h))?;
+                Ok(raw.into_iter().map(|p| (p as i128 + bz) as $t).collect())
+            }
+
+            fn read_section(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                range: std::ops::Range<usize>,
+            ) -> Result<Vec<Self>> {
+                let count = range.end.saturating_sub(range.start);
+                let (raw, bz) = read_raw_with_bzero(file, hdu, |d, h| {
+                    crate::image::read_image_section(d, h, range.start, count)
+                })?;
+                Ok(raw.into_iter().map(|p| (p as i128 + bz) as $t).collect())
+            }
+
+            fn read_rows(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                start_row: usize,
+                num_rows: usize,
+            ) -> Result<Vec<Self>> {
+                let (raw, bz) = read_raw_with_bzero(file, hdu, |d, h| {
+                    crate::image::read_image_rows(d, h, start_row, num_rows)
+                })?;
+                Ok(raw.into_iter().map(|p| (p as i128 + bz) as $t).collect())
+            }
+
+            fn read_region(
+                file: &FitsFile,
+                hdu: &FitsHdu,
+                ranges: &[std::ops::Range<usize>],
+            ) -> Result<Vec<Self>> {
+                let tuples = ranges_to_tuples(ranges);
+                let (raw, bz) = read_raw_with_bzero(file, hdu, |d, h| {
+                    crate::image::read_image_region(d, h, &tuples)
+                })?;
+                Ok(raw.into_iter().map(|p| (p as i128 + bz) as $t).collect())
+            }
+        }
+    };
+}
+
+impl_read_image_unsigned!(u16);
+impl_read_image_unsigned!(u32);
+impl_read_image_unsigned!(u64);
 
 macro_rules! impl_read_image {
     ($t:ty, $u8_fn:expr, $i16_fn:expr, $i32_fn:expr, $i64_fn:expr, $f32_fn:expr, $f64_fn:expr) => {
@@ -257,59 +362,78 @@ impl_read_image!(
     |v: &[f64]| v.to_vec()
 );
 
+/// Splice already-serialized pixel bytes into the HDU's data region, preserving
+/// any subsequent HDUs.
+fn write_serialized(file: &mut FitsFile, hdu: &FitsHdu, serialized: &[u8]) -> Result<()> {
+    // Read HDU metadata from cache before mutating.
+    let (data_start, padded_data_len, file_len) = {
+        let parsed = file.parsed()?;
+        let core_hdu = parsed
+            .hdus
+            .get(hdu.hdu_index)
+            .ok_or(Error::Message(format!(
+                "HDU index {} out of range",
+                hdu.hdu_index
+            )))?;
+        let padded = crate::block::padded_byte_len(core_hdu.data_len);
+        (core_hdu.data_start, padded, file.data().len())
+    };
+
+    let next_hdu_start = data_start + padded_data_len;
+    let tail_len = file_len.saturating_sub(next_hdu_start);
+
+    let mut new_data = Vec::with_capacity(data_start + serialized.len() + tail_len);
+    new_data.extend_from_slice(&file.data()[..data_start]);
+    new_data.extend_from_slice(serialized);
+    if tail_len > 0 {
+        new_data.extend_from_slice(&file.data()[next_hdu_start..]);
+    }
+
+    file.set_data(new_data);
+    Ok(())
+}
+
 macro_rules! impl_write_image {
-    ($t:ty, $bitpix:expr, $serialize_fn:path) => {
+    ($t:ty, $serialize_fn:path) => {
         impl WriteImage for $t {
             fn write_image(file: &mut FitsFile, hdu: &FitsHdu, data: &[Self]) -> Result<()> {
-                // Read HDU metadata from cache before mutating
-                let (header_end, data_start, padded_data_len, file_len) = {
-                    let parsed = file.parsed()?;
-                    let core_hdu =
-                        parsed
-                            .hdus
-                            .get(hdu.hdu_index)
-                            .ok_or(Error::Message(format!(
-                                "HDU index {} out of range",
-                                hdu.hdu_index
-                            )))?;
-                    let padded = crate::block::padded_byte_len(core_hdu.data_len);
-                    (
-                        core_hdu.data_start,
-                        core_hdu.data_start,
-                        padded,
-                        file.data().len(),
-                    )
-                };
-
-                let serialized = $serialize_fn(data);
-
-                let next_hdu_start = data_start + padded_data_len;
-                let tail_len = if next_hdu_start < file_len {
-                    file_len - next_hdu_start
-                } else {
-                    0
-                };
-
-                let mut new_data = Vec::with_capacity(header_end + serialized.len() + tail_len);
-                new_data.extend_from_slice(&file.data()[..header_end]);
-                new_data.extend_from_slice(&serialized);
-                if tail_len > 0 {
-                    new_data.extend_from_slice(&file.data()[next_hdu_start..]);
-                }
-
-                file.set_data(new_data);
-                Ok(())
+                write_serialized(file, hdu, &$serialize_fn(data))
             }
         }
     };
 }
 
-impl_write_image!(u8, 8, crate::image::serialize_image_u8);
-impl_write_image!(i16, 16, crate::image::serialize_image_i16);
-impl_write_image!(i32, 32, crate::image::serialize_image_i32);
-impl_write_image!(i64, 64, crate::image::serialize_image_i64);
-impl_write_image!(f32, -32, crate::image::serialize_image_f32);
-impl_write_image!(f64, -64, crate::image::serialize_image_f64);
+impl_write_image!(u8, crate::image::serialize_image_u8);
+impl_write_image!(i16, crate::image::serialize_image_i16);
+impl_write_image!(i32, crate::image::serialize_image_i32);
+impl_write_image!(i64, crate::image::serialize_image_i64);
+impl_write_image!(f32, crate::image::serialize_image_f32);
+impl_write_image!(f64, crate::image::serialize_image_f64);
+
+/// Write an unsigned image using the cfitsio storage convention: each value is
+/// offset by `-BZERO` (a sign-bit flip) into the signed storage type before
+/// serialization. The matching `BZERO`/`BSCALE` keywords are written by
+/// `create_image`.
+macro_rules! impl_write_image_unsigned {
+    ($t:ty, $signed:ty, $sign_bit:expr, $serialize_fn:path) => {
+        impl WriteImage for $t {
+            fn write_image(file: &mut FitsFile, hdu: &FitsHdu, data: &[Self]) -> Result<()> {
+                let storage: Vec<$signed> =
+                    data.iter().map(|&u| (u ^ $sign_bit) as $signed).collect();
+                write_serialized(file, hdu, &$serialize_fn(&storage))
+            }
+        }
+    };
+}
+
+impl_write_image_unsigned!(u16, i16, 0x8000, crate::image::serialize_image_i16);
+impl_write_image_unsigned!(u32, i32, 0x8000_0000, crate::image::serialize_image_i32);
+impl_write_image_unsigned!(
+    u64,
+    i64,
+    0x8000_0000_0000_0000,
+    crate::image::serialize_image_i64
+);
 
 #[cfg(test)]
 mod tests {
@@ -388,6 +512,81 @@ mod tests {
 
         let read_back = u8::read_image(&f, &hdu).unwrap();
         assert_eq!(read_back, pixels);
+    }
+
+    fn roundtrip_unsigned<T>(data_type: ImageType, pixels: Vec<T>)
+    where
+        T: ReadImage + WriteImage + Clone + PartialEq + std::fmt::Debug,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("img.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+
+        let desc = ImageDescription {
+            data_type,
+            dimensions: vec![pixels.len()],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        <T as WriteImage>::write_image(&mut f, &hdu, &pixels).unwrap();
+
+        let read_back = <T as ReadImage>::read_image(&f, &hdu).unwrap();
+        assert_eq!(read_back, pixels);
+    }
+
+    #[test]
+    fn create_and_read_image_u16() {
+        // Includes 0, the BZERO midpoint, and the max value.
+        roundtrip_unsigned::<u16>(
+            ImageType::UnsignedShort,
+            vec![0, 1, 32767, 32768, 40000, 65535],
+        );
+    }
+
+    #[test]
+    fn create_and_read_image_u32() {
+        roundtrip_unsigned::<u32>(
+            ImageType::UnsignedLong,
+            vec![0, 1, 2_147_483_647, 2_147_483_648, u32::MAX],
+        );
+    }
+
+    #[test]
+    fn create_and_read_image_u64() {
+        roundtrip_unsigned::<u64>(
+            ImageType::UnsignedLongLong,
+            vec![
+                0,
+                1,
+                9_223_372_036_854_775_807,
+                9_223_372_036_854_775_808,
+                u64::MAX,
+            ],
+        );
+    }
+
+    #[test]
+    fn u16_uses_cfitsio_storage_convention() {
+        // A u16 image must be stored as BITPIX=16 + BZERO=32768, with the raw
+        // signed pixels offset by -32768, so cfitsio (and other readers) recover
+        // the unsigned values.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("u16.fits");
+        let mut f = FitsFile::create(&path).open().unwrap();
+        let desc = ImageDescription {
+            data_type: ImageType::UnsignedShort,
+            dimensions: vec![3],
+        };
+        let hdu = f.create_image("SCI", &desc).unwrap();
+        u16::write_image(&mut f, &hdu, &[0u16, 32768, 65535]).unwrap();
+
+        // BZERO keyword present and correct.
+        use crate::compat::headers::ReadsKey;
+        let bzero: i64 = i64::read_key(&f, &hdu, "BZERO").unwrap();
+        assert_eq!(bzero, 32768);
+
+        // Raw signed storage is value - 32768.
+        let raw: Vec<i16> = i16::read_image(&f, &hdu).unwrap();
+        assert_eq!(raw, vec![-32768, 0, 32767]);
     }
 
     #[test]


### PR DESCRIPTION
Implements part 1 of #64 — the highest-value gap for adopters.

## What

Native `WriteImage`/`ReadImage` for `u16`, `u32`, and `u64`, using the **cfitsio unsigned-integer storage convention**: signed `BITPIX` plus a `BZERO` offset of `2^(n-1)`.

New `ImageType` variants `UnsignedShort` / `UnsignedLong` / `UnsignedLongLong`:

- `create_image` emits `BZERO` (32768 / 2³¹ / 2⁶³) and `BSCALE = 1`.
- **Writes** store the sign-bit-flipped value into the signed storage type.
- **Reads** recover the unsigned value from the header `BZERO` (works for any reader's offset, defaulting to a plain cast when `BZERO` is absent).

u64's `BZERO` is 2⁶³ which exceeds `i64::MAX`, so it's stored as a float (2⁶³ is exactly representable in f64).

### Before / after for adopters

```rust
// before: hand-rolled at the call site
let pixels: Vec<i16> = frame.iter().map(|&v| (v as i32 - 32768) as i16).collect();
i16::write_image(&mut file, &hdu, &pixels)?;
i64::write_key(&mut file, &hdu, "BZERO", &32768)?;
i64::write_key(&mut file, &hdu, "BSCALE", &1)?;

// after
u16::write_image(&mut file, &hdu, &frame)?;   // create_image(UnsignedShort) handles BZERO/BSCALE
```

## Implementation notes

- Image-write byte-splicing is factored into a shared `write_serialized` helper used by both the signed and unsigned write paths (no behavior change for existing types).

## Tests

- Round-trips for u16/u32/u64 at edge values: `0`, the BZERO midpoint, and `MAX`.
- `u16_uses_cfitsio_storage_convention`: asserts `BZERO=32768` is written and the raw signed storage is `value - 32768`, so cfitsio and other readers recover the unsigned values.

```
cargo test --features array            # all green
cargo clippy --all-targets --features array -- -D warnings   # clean
```

## Follow-up

Once the #65 parity harness lands, extend it with u16/u32 cases (the `fitsio` crate supports `UnsignedShort`/`UnsignedLong`) to cross-validate this convention against cfitsio directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)