### PR TITLE
Pin Rust toolchain to 1.96.0 (+ clippy fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
       - run: cargo test --workspace
       - run: cargo test --features array
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown
       - run: cargo build --target wasm32-unknown-unknown -p fitsio-pure
@@ -51,5 +51,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
       - run: cargo build --features cli

--- a/crates/fitsio-pure/src/image.rs
+++ b/crates/fitsio-pure/src/image.rs
@@ -139,7 +139,7 @@ pub fn read_image_data_into_f32(fits_data: &[u8], hdu: &Hdu, buf: &mut [f32]) ->
     let bitpix = hdu_bitpix(hdu)?;
     let bpp = bytes_per_pixel(bitpix)?;
     let data_len = hdu.data_len;
-    let npixels = if bpp > 0 { data_len / bpp } else { 0 };
+    let npixels = data_len.checked_div(bpp).unwrap_or(0);
 
     if buf.len() != npixels {
         return Err(Error::InvalidValue);
@@ -199,7 +199,7 @@ pub fn read_image_data_into_f64(fits_data: &[u8], hdu: &Hdu, buf: &mut [f64]) ->
     let bitpix = hdu_bitpix(hdu)?;
     let bpp = bytes_per_pixel(bitpix)?;
     let data_len = hdu.data_len;
-    let npixels = if bpp > 0 { data_len / bpp } else { 0 };
+    let npixels = data_len.checked_div(bpp).unwrap_or(0);
 
     if buf.len() != npixels {
         return Err(Error::InvalidValue);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pin the toolchain so CI and local builds use a deterministic Rust version.
+# Bumping this is an explicit, reviewable change (new lints land with new
+# versions); see the CI clippy job.
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary

Pins CI and local builds to a deterministic Rust version instead of floating `stable`, so a new stable release's lints arrive as an explicit, reviewable toolchain bump rather than surprise red CI on unrelated PRs (which is exactly what just happened — 1.96.0 added a new clippy lint).

- Adds `rust-toolchain.toml` (channel `1.96.0`; `clippy`/`rustfmt` components, `wasm32-unknown-unknown` target) so `rustup`/`cargo` pin locally too.
- Pins the `dtolnay/rust-toolchain` action from `@stable` → `@1.96.0` across all CI jobs.
- Fixes the `manual_checked_ops` lint 1.96.0 introduced: the two `if bpp > 0 { data_len / bpp } else { 0 }` guards in `image.rs` become `data_len.checked_div(bpp).unwrap_or(0)` (functionally identical).

## Verification

On the pinned 1.96.0, locally and in CI:

- `cargo clippy --workspace --all-targets -- -D warnings` and `--features array` — clean
- full test suite (`--features array`) — green
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
