### PR TITLE
Release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "fitsio-pure"
-version = "1.0.2"
+version = "0.12.0"
 dependencies = [
  "bytemuck",
  "libm",

--- a/crates/fitsio-pure/Cargo.toml
+++ b/crates/fitsio-pure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-pure"
-version = "1.0.2"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Pure Rust FITS file reader and writer"


### PR DESCRIPTION
Sets the published version to **0.12.0**, continuing the crates.io 0.x lineage (latest published: `0.11.0`).

The repo had been bumped to a never-published `1.0.2` in #54 (an arbitrary jump from `0.11.0`); this corrects it back to the real lineage.

## Ships
- Native unsigned image support — u16/u32/u64 (#67, #64.1)
- ndarray write path (#68, #64.2)
- ndarray read axis-order fix (#66, #64.3)
- compat↔cfitsio parity harness, now a required CI check (#65)

`cargo publish --dry-run` clean (packages 33 files, verification build compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)